### PR TITLE
Removed ClientConfig

### DIFF
--- a/packages/generator/templates/ClientInstance.ts.hbs
+++ b/packages/generator/templates/ClientInstance.ts.hbs
@@ -44,4 +44,3 @@ export class Client extends BaseClient {
 }
 
 export default Client;
-export { ClientConfig };


### PR DESCRIPTION
We expose the ClientConfig type a the root namespace of the SDK.  It is confusing to then export it at each client level as well. This just removed that redundant export as it shouldn't be needed.