### PR TITLE
auth helper changes

### DIFF
--- a/packages/generator/templates/helpers.ts.hbs
+++ b/packages/generator/templates/helpers.ts.hbs
@@ -6,14 +6,23 @@ import  * as sdk from "./"
 type authFuncParamType = Parameters<typeof sdk.{{shopperAuthClient}}.Client.prototype.{{shopperAuthApi}}>[0];
 
 /**
- * @description This wraps the parameters for the authCall to retrieve a token. 
+ * @description This wraps the parameters for the authorization call to retrieve a token.
  * That call can be made directly, this is here just for convenience
- *
+ * @example
+ * const clientConfig: ClientConfig = {
+    parameters: {
+        clientId: "XXXXXX",
+        organizationId: "XXXX",
+        shortCode: "XXX",
+        siteId: "XX"
+    }
+   };
+   helpers.getShopperToken(clientConfig, { type: "guest" })
  * @param clientConfig Client configuration properties
  * @param body Post body required for authorization
  * @returns {Promise<ShopperToken>}
  */
-export async function getShopperAuthToken (
+export async function getShopperToken (
     clientConfig: sdk.ClientConfig,
     body: authFuncParamType["body"]
 ): Promise<ShopperToken>{
@@ -32,7 +41,7 @@ export async function getShopperAuthToken (
 const shopperAuthApi = sdk.{{shopperAuthClient}}.Client.prototype.{{shopperAuthApi}};
 
 /**
-* @deprecated Use the "getShopperAuthToken" function instead
+* @deprecated Use the "getShopperToken" function instead
 * @description This wraps the parameters for the authCall to retrieve a token.
 *  That call can be called directly, this is here just for convenience
 * @export

--- a/packages/generator/templates/helpers.ts.hbs
+++ b/packages/generator/templates/helpers.ts.hbs
@@ -1,5 +1,5 @@
 
-import { ShopperToken, stripBearer } from "@commerce-apps/core"
+import { ShopperToken, stripBearer, ResponseError } from "@commerce-apps/core"
 import  * as sdk from "./"
 
 //type of the input parameter of auth function
@@ -33,7 +33,7 @@ export async function getShopperToken (
         body: body
     })) as Response;
     if (!response.ok) {
-        throw new Error(`${response.status}: ${response.statusText}`);
+        throw new ResponseError(response);
     }
     return new ShopperToken(stripBearer(response.headers.get("Authorization")));
 }

--- a/packages/generator/templates/helpers.ts.hbs
+++ b/packages/generator/templates/helpers.ts.hbs
@@ -2,31 +2,67 @@
 import { ShopperToken, stripBearer } from "@commerce-apps/core"
 import  * as sdk from "./"
 
+//type of the input parameter of auth function
+type authFuncParamType = Parameters<typeof sdk.{{shopperAuthClient}}.Client.prototype.{{shopperAuthApi}}>[0];
+
+/**
+ * @description This wraps the parameters for the authCall to retrieve a token. 
+ * That call can be made directly, this is here just for convenience
+ *
+ * @param clientConfig Client configuration properties
+ * @param body Post body required for authorization
+ * @returns {Promise<ShopperToken>}
+ */
+export async function getShopperAuthToken (
+    clientConfig: sdk.ClientConfig,
+    body: authFuncParamType["body"]
+): Promise<ShopperToken>{
+    let client = new sdk.{{shopperAuthClient}}.Client(clientConfig);
+
+    let response = (await client.{{shopperAuthApi}}({
+        rawResponse: true,
+        body: body
+    })) as Response;
+    if (!response.ok) {
+        throw new Error(`${response.status}: ${response.statusText}`);
+    }
+    return new ShopperToken(stripBearer(response.headers.get("Authorization")));
+}
 
 const shopperAuthApi = sdk.{{shopperAuthClient}}.Client.prototype.{{shopperAuthApi}};
 
 /**
- * @description This wraps the parameters for the authCall to retrieve a token. 
- *  That call can be called directly, this is here just for convenience
- * @export
- * @template T A template used to extend the parameters of the shopper authentication call
- * @param clientConfig Client configuration properties
- * @param options Properties to get the auth token. Properties that are already set in clientConfig can be omitted
- * @returns {Promise<ShopperToken>}
- */
+* @deprecated Use the "getShopperAuthToken" function instead
+* @description This wraps the parameters for the authCall to retrieve a token.
+*  That call can be called directly, this is here just for convenience
+* @export
+* @template T A template used to extend the parameters of the shopper authentication call
+* @param {(T extends (arg: infer A) => any
+*           ? { parameters: { clientId?: string; shortCode?: string } } & A
+*           : never)} options This provides the type ahead for this parameter properly
+* @returns {Promise<ShopperToken>}
+*/
 export async function getAuthToken<T extends typeof shopperAuthApi>(
-        clientConfig: sdk.ClientConfig,
-        options: T extends (arg: infer A) => any ? A : never
-    ): Promise<ShopperToken>{
+    options: T extends (arg: infer A) => any
+    ? { parameters: { clientId?: string; shortCode?: string } } & A
+    : never
+    ): Promise<ShopperToken> {
 
-        let client = new sdk.{{shopperAuthClient}}.Client(clientConfig);
+    let client = new sdk.{{shopperAuthClient}}.Client({
+    parameters: {
+    shortCode: options.parameters.shortCode
+    }
+    });
 
-        options.rawResponse = true;
+    options.rawResponse = true;
 
-        let response = await client.authorizeCustomer(options) as Response;
-        if (!response.ok) {
-                throw new Error(`${response.status}: ${response.statusText}`)
-        }
-        
-        return new ShopperToken(stripBearer(response.headers.get("Authorization")));
+    // At some point this should go through the same stripping as everything else.
+    //  Should be part of the global config story
+    delete options.parameters.shortCode;
+
+    let response = await client.authorizeCustomer(options) as Response;
+    if (!response.ok) {
+    throw new Error(`${response.status}: ${response.statusText}`)
+    }
+    return new ShopperToken(stripBearer(response.headers.get("Authorization")));
 }


### PR DESCRIPTION
1. Added back the previous version of getAuthToken function and marked as deprecated
2. Renamed the current version of getAuthToken function to getShopperAuthToken 
3. Simplified the input params of getShopperAuthToken