### PR TITLE
Remove unnecessary arrays used for API model while rendering the templates

### DIFF
--- a/packages/generator/src/parser.ts
+++ b/packages/generator/src/parser.ts
@@ -73,23 +73,18 @@ export function getReferenceDataTypes(
 }
 
 export function getAllDataTypes(
-  apis: WebApiBaseUnitWithDeclaresModel[]
+  api: WebApiBaseUnitWithDeclaresModel
 ): model.domain.CustomDomainProperty[] {
   let ret: model.domain.CustomDomainProperty[] = [];
   const dataTypes: Set<string> = new Set();
-  apis.forEach(element => {
-    element
-      .references()
-      .forEach((reference: WebApiBaseUnitWithDeclaresModel) => {
-        if (reference.declares) {
-          ret = ret.concat(
-            getDataTypesFromDeclare(reference.declares, dataTypes)
-          );
-        }
-      });
-    ret = ret.concat(getDataTypesFromDeclare(element.declares, dataTypes));
-    getReferenceDataTypes(element.references(), ret, dataTypes);
-  });
+  const temp: model.domain.CustomDomainProperty[] = getDataTypesFromDeclare(
+    api.declares,
+    dataTypes
+  );
+  if (temp != null) {
+    ret = temp;
+  }
+  getReferenceDataTypes(api.references(), ret, dataTypes);
   return ret;
 }
 

--- a/packages/generator/src/renderer.ts
+++ b/packages/generator/src/renderer.ts
@@ -93,15 +93,15 @@ const dtoPartial = Handlebars.compile(
 );
 
 function createClient(
-  webApiModels: WebApiBaseUnit[],
+  webApiModel: WebApiBaseUnit,
   boundedContext: string
 ): string {
-  const clientCode: string = clientInstanceTemplate(
+  return clientInstanceTemplate(
     {
       dataTypes: getAllDataTypes(
-        webApiModels as WebApiBaseUnitWithDeclaresModel[]
+        webApiModel as WebApiBaseUnitWithDeclaresModel
       ),
-      models: webApiModels,
+      apiModel: webApiModel,
       apiSpec: boundedContext
     },
     {
@@ -109,13 +109,10 @@ function createClient(
       allowProtoMethodsByDefault: true
     }
   );
-  return clientCode;
 }
 
-function createDto(webApiModels: WebApiBaseUnit[]): string {
-  const types = getAllDataTypes(
-    webApiModels as WebApiBaseUnitWithDeclaresModel[]
-  );
+function createDto(webApiModel: WebApiBaseUnit): string {
+  const types = getAllDataTypes(webApiModel as WebApiBaseUnitWithDeclaresModel);
   return dtoTemplate(types, {
     allowProtoPropertiesByDefault: true,
     allowProtoMethodsByDefault: true
@@ -172,19 +169,19 @@ function renderApi(
   const apiName: string = getApiName(apiModel);
   const apiPath: string = path.join(renderDir, apiName);
   fs.ensureDirSync(apiPath);
-  //TODO: Modify createClient and createDto functions to take a single model object instead of array and get rid of apiModels array
-  const apiModels: WebApiBaseUnitWithEncodesModel[] = [apiModel];
+
   fs.writeFileSync(
     path.join(apiPath, `${apiName}.types.ts`),
-    createDto(apiModels)
+    createDto(apiModel)
   );
   //Resolve model for the end points Using the 'editing' pipeline will retain the declarations in the model
-  const apiModelsForEndPoints: WebApiBaseUnitWithEncodesModel[] = [
-    resolveApiModel(apiModel, "editing")
-  ];
+  const apiModelForEndPoints: WebApiBaseUnitWithEncodesModel = resolveApiModel(
+    apiModel,
+    "editing"
+  );
   fs.writeFileSync(
     path.join(apiPath, `${apiName}.ts`),
-    createClient(apiModelsForEndPoints, apiName)
+    createClient(apiModelForEndPoints, apiName)
   );
   return apiName;
 }

--- a/packages/generator/templates/ClientInstance.ts.hbs
+++ b/packages/generator/templates/ClientInstance.ts.hbs
@@ -32,14 +32,12 @@ export class Client extends BaseClient {
     super(config);
 
     if (!!!config.baseUri) {
-      this.clientConfig.baseUri = "{{getBaseUri models.[0] }}";
+      this.clientConfig.baseUri = "{{getBaseUri apiModel}}";
     }
 
   }
 
-{{#each models}}
-    {{> operationsPartial model=. }}
-{{/each}}
+  {{> operationsPartial model=apiModel }}
 
 }
 

--- a/packages/generator/test/parser.test.ts
+++ b/packages/generator/test/parser.test.ts
@@ -51,7 +51,7 @@ describe("Get Data types", () => {
   it("Test valid RAML file", () => {
     const ramlFile = path.join(__dirname, "/raml/valid/site/site.raml");
     return processRamlFile(ramlFile).then(s => {
-      const res = getAllDataTypes([s as WebApiBaseUnitWithDeclaresModel]);
+      const res = getAllDataTypes(s as WebApiBaseUnitWithDeclaresModel);
       expect(_.map(res, res => res.name.value())).to.be.deep.equal([
         "product_search_result",
         "ClassA",
@@ -76,7 +76,7 @@ describe("Get Data types", () => {
         });
       })
       .then(s => {
-        const res = getAllDataTypes([s as WebApiBaseUnitWithDeclaresModel]);
+        const res = getAllDataTypes(s as WebApiBaseUnitWithDeclaresModel);
         expect(_.map(res, res => res.name.value())).to.be.deep.equal([
           "product_search_result",
           "ClassA",


### PR DESCRIPTION
This change addresses the TODO comment that was added with api re-org story. 
Got rid of the code to create an array with single api model while rendering the templates