### PR TITLE
Ja/fix client org

### DIFF
--- a/base.tsconfig.json
+++ b/base.tsconfig.json
@@ -7,7 +7,6 @@
         "sourceMap": true,
         "target": "ES6",
         "esModuleInterop": true,
-        "declarationMap": true,
         "forceConsistentCasingInFileNames":true,
         "importHelpers": true,
         "incremental": false,
@@ -17,6 +16,5 @@
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "preserveConstEnums": true
-        
     }
 }

--- a/packages/core/src/base/resource.ts
+++ b/packages/core/src/base/resource.ts
@@ -43,7 +43,9 @@ export class Resource {
       this.pathParameters
     );
 
-    const queryString = qs.stringify(this.queryParameters, { arrayFormat: "repeat" });
+    const queryString = qs.stringify(this.queryParameters, {
+      arrayFormat: "repeat"
+    });
 
     return `${renderedBaseUri}${renderedPath}${
       queryString ? "?" : ""

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -15,7 +15,7 @@
     "pretest": "npm run lint",
     "test:debug": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\" --require ts-node/register --require source-map-support/register --timeout 5000 --colors",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\" --require ts-node/register --require source-map-support/register --reporter=xunit --reporter-options output=../../reports/generator.xml --colors",
-    "test:integration": "nyc --silent --check-coverage=false cross-env TS_NODE_FILES=true mocha --reporter=xunit --reporter-options output=../../reports/generator-integration.xml  --exit --require ts-node/register --colors --timeout 15000 test_integration/**/*.ts",
+    "test:integration": "nyc --extension .ts mocha --forbid-only \"test_integration/**/*.ts\" --require ts-node/register --require source-map-support/register  --colors --reporter=xunit --reporter-options output=../../reports/generator-integration.xml",
     "start": "node dist/index.js",
     "clean": "gulp clean",
     "buildOperationList": "gulp buildOperationList",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -15,7 +15,7 @@
     "pretest": "npm run lint",
     "test:debug": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\" --require ts-node/register --require source-map-support/register --timeout 5000 --colors",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\" --require ts-node/register --require source-map-support/register --reporter=xunit --reporter-options output=../../reports/generator.xml --colors",
-    "test:integration": "nyc --extension .ts mocha --forbid-only \"test_integration/**/*.ts\" --require ts-node/register --require source-map-support/register  --colors --reporter=xunit --reporter-options output=../../reports/generator-integration.xml",
+    "test:integration": "nyc --check-coverage=false --extension .ts mocha --forbid-only \"test_integration/**/*.ts\" --require ts-node/register --require source-map-support/register  --colors --reporter=xunit --reporter-options output=../../reports/generator-integration.xml",
     "start": "node dist/index.js",
     "clean": "gulp clean",
     "buildOperationList": "gulp buildOperationList",

--- a/packages/generator/src/renderer.ts
+++ b/packages/generator/src/renderer.ts
@@ -92,17 +92,14 @@ const dtoPartial = Handlebars.compile(
   fs.readFileSync(path.join(templateDirectory, "dtoPartial.ts.hbs"), "utf8")
 );
 
-function createClient(
-  webApiModels: WebApiBaseUnit[],
-  boundedContext: string
-): string {
+function createClient(webApiModels: WebApiBaseUnit[], apiName: string): string {
   const clientCode: string = clientInstanceTemplate(
     {
       dataTypes: getAllDataTypes(
         webApiModels as WebApiBaseUnitWithDeclaresModel[]
       ),
       models: webApiModels,
-      apiSpec: boundedContext
+      apiSpec: apiName
     },
     {
       allowProtoPropertiesByDefault: true,

--- a/packages/generator/src/templateHelpers.ts
+++ b/packages/generator/src/templateHelpers.ts
@@ -164,7 +164,7 @@ export const getReturnPayloadType = function(operation: any): string {
       dataTypes.push(
         res.payloads[0].schema.name.value() === "schema"
           ? "Object"
-          : res.payloads[0].schema.name.value()
+          : res.payloads[0].schema.name.value() + "T"
       );
     } else {
       dataTypes.push("void");
@@ -210,7 +210,7 @@ export const getArrayElementTypeProperty = function(property: any): string {
   }
 
   if (isTypeDefined(itemsObject)) {
-    result = itemsObject.inherits[0].linkTarget.name.value();
+    result = itemsObject.inherits[0].linkTarget.name.value() + "T";
   }
 
   if (
@@ -219,7 +219,7 @@ export const getArrayElementTypeProperty = function(property: any): string {
     itemsObject.linkTarget.name !== undefined &&
     itemsObject.linkTarget.name.value !== undefined
   ) {
-    result = itemsObject.linkTarget.name.value();
+    result = itemsObject.linkTarget.name.value() + "T";
   }
 
   return result;
@@ -232,7 +232,7 @@ export const getDataType = function(property: any): string {
     return getDataTypeFromMap(range.dataType.value());
   }
   if (isTypeDefined(range)) {
-    return range.inherits[0].linkTarget.name.value();
+    return range.inherits[0].linkTarget.name.value() + "T";
   }
 
   if (isTypeLinked(range)) {

--- a/packages/generator/templates/ClientInstance.ts.hbs
+++ b/packages/generator/templates/ClientInstance.ts.hbs
@@ -5,15 +5,7 @@ import _ from "lodash";
 import {
 {{#each dataTypes}}
     {{#if (isTypeDefinition .)}}
-        {{getValue name}},
-    {{/if}}
-{{/each}}
-} from "./{{apiSpec}}.types";
-
-export {
-{{#each dataTypes}}
-    {{#if (isTypeDefinition .)}}
-        {{getValue name}},
+        {{getValue name}}T,
     {{/if}}
 {{/each}}
 } from "./{{apiSpec}}.types";
@@ -27,7 +19,7 @@ export {
 * ClientConfig object. The Client will use that Authorization header for all the
 * operations it is used to perform.
 */
-export class Client extends BaseClient {
+class {{capitalize apiSpec}} extends BaseClient {
   constructor(config: ClientConfig) {
     super(config);
 
@@ -43,4 +35,13 @@ export class Client extends BaseClient {
 
 }
 
-export default Client;
+// eslint-disable-next-line @typescript-eslint/no-namespace
+declare module {{capitalize apiSpec}} {
+  {{#each dataTypes}}
+      {{#if (isTypeDefinition .)}}
+         export type {{getValue name}}={{getValue name}}T
+      {{/if}}
+  {{/each}}
+}
+
+export = {{capitalize apiSpec}}

--- a/packages/generator/templates/apiFamily.ts.hbs
+++ b/packages/generator/templates/apiFamily.ts.hbs
@@ -1,8 +1,9 @@
 {{#each apiNamesInFamily}}
-import * as {{capitalize .}} from "./{{.}}/{{.}}";
+import {{capitalize .}} from "./{{.}}/{{.}}";
 {{/each}}
 export {
 {{#each apiNamesInFamily}}
     {{capitalize .}}{{#unless @last}},{{/unless}}
 {{/each}}
 }
+

--- a/packages/generator/templates/dto.ts.hbs
+++ b/packages/generator/templates/dto.ts.hbs
@@ -1,5 +1,5 @@
 {{#each .}}
     {{#if (isTypeDefinition .)}}
-export type {{getValue name}} = {{> dtoPartial typeDto=. }}
+export type {{getValue name}}T = {{> dtoPartial typeDto=. }}
     {{/if}}
 {{/each}}

--- a/packages/generator/templates/helpers.ts.hbs
+++ b/packages/generator/templates/helpers.ts.hbs
@@ -3,7 +3,7 @@ import { ShopperToken, stripBearer, ResponseError } from "@commerce-apps/core"
 import  * as sdk from "./"
 
 //type of the input parameter of auth function
-type authFuncParamType = Parameters<typeof sdk.{{shopperAuthClient}}.Client.prototype.{{shopperAuthApi}}>[0];
+type authFuncParamType = Parameters<typeof sdk.{{shopperAuthClient}}.prototype.{{shopperAuthApi}}>[0];
 
 /**
  * @description This wraps the parameters for the authorization call to retrieve a token.
@@ -26,7 +26,7 @@ export async function getShopperToken (
     clientConfig: sdk.ClientConfig,
     body: authFuncParamType["body"]
 ): Promise<ShopperToken>{
-    let client = new sdk.{{shopperAuthClient}}.Client(clientConfig);
+    let client = new sdk.{{shopperAuthClient}}(clientConfig);
 
     let response = (await client.{{shopperAuthApi}}({
         rawResponse: true,
@@ -38,7 +38,7 @@ export async function getShopperToken (
     return new ShopperToken(stripBearer(response.headers.get("Authorization")));
 }
 
-const shopperAuthApi = sdk.{{shopperAuthClient}}.Client.prototype.{{shopperAuthApi}};
+type shopperAuthApi = typeof sdk.{{shopperAuthClient}}.prototype.{{shopperAuthApi}};
 
 /**
 * @deprecated Use the "getShopperToken" function instead
@@ -51,13 +51,13 @@ const shopperAuthApi = sdk.{{shopperAuthClient}}.Client.prototype.{{shopperAuthA
 *           : never)} options This provides the type ahead for this parameter properly
 * @returns {Promise<ShopperToken>}
 */
-export async function getAuthToken<T extends typeof shopperAuthApi>(
+export async function getAuthToken<T extends shopperAuthApi>(
     options: T extends (arg: infer A) => any
     ? { parameters: { clientId?: string; shortCode?: string } } & A
     : never
     ): Promise<ShopperToken> {
 
-    let client = new sdk.{{shopperAuthClient}}.Client({
+    let client = new sdk.{{shopperAuthClient}}({
     parameters: {
     shortCode: options.parameters.shortCode
     }

--- a/packages/generator/test/template-helpers.test.ts
+++ b/packages/generator/test/template-helpers.test.ts
@@ -92,7 +92,7 @@ describe("Template helper primitive datatype tests", () => {
       }
     };
 
-    assert.isTrue(getDataType(property) === "defined_type");
+    assert.isTrue(getDataType(property) === "defined_typeT");
   });
 
   it("Returns 'boolean' on boolean linked dataType", () => {
@@ -175,7 +175,7 @@ describe("Template helper Array item type tests", () => {
         }
       }
     };
-    assert.isTrue(getDataType(property) === "Array<defined_type>");
+    assert.isTrue(getDataType(property) === "Array<defined_typeT>");
   });
 
   it("Returns 'Array<any>' on array of object dataType with isLink as false", () => {
@@ -235,7 +235,7 @@ describe("Template helper Array item type tests", () => {
         }
       }
     };
-    assert.isTrue(getArrayElementTypeProperty(property) === "defined_type");
+    assert.isTrue(getArrayElementTypeProperty(property) === "defined_typeT");
   });
 
   it("Returns 'any' on array of defined_type items, but isLink is false", () => {
@@ -324,7 +324,7 @@ describe("Template helper tests array literal definitions like string[], defined
         ]
       }
     };
-    assert.equal(getArrayElementTypeProperty(property), "defined_type");
+    assert.equal(getArrayElementTypeProperty(property), "defined_typeT");
   });
 });
 
@@ -353,7 +353,7 @@ describe("Template helper, response item type tests", () => {
     const response: model.domain.Response = operation.responses[0];
     response.withStatusCode("200");
     response.payloads[0].schema.withName("DefinedType");
-    expect(getReturnPayloadType(operation)).to.equal("Response | DefinedType");
+    expect(getReturnPayloadType(operation)).to.equal("Response | DefinedTypeT");
   });
 
   it("Returns 'Response | void' on defined_type datatype, but with statusCode as 500", () => {

--- a/packages/generator/test_integration/site-integration.test.ts
+++ b/packages/generator/test_integration/site-integration.test.ts
@@ -11,7 +11,6 @@ import chaiAsPromised from "chai-as-promised";
 const BASE_URI =
   "https://anypoint.mulesoft.com/mocking/api/v1/sources/exchange/assets/893f605e-10e2-423a-bdb4-f952f56eb6d8/steelarc-integration/1.0.0/m/s/-/dw/shop/v19_5";
 
-console.log(Shop.ShopApi);
 const client = new Shop.ShopApi({
   baseUri: BASE_URI
 });

--- a/packages/generator/test_integration/site-integration.test.ts
+++ b/packages/generator/test_integration/site-integration.test.ts
@@ -6,17 +6,18 @@
  */
 "use strict";
 import { Shop } from "../dist";
-import chai from "chai";
+import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
-const expect = chai.expect;
 const BASE_URI =
   "https://anypoint.mulesoft.com/mocking/api/v1/sources/exchange/assets/893f605e-10e2-423a-bdb4-f952f56eb6d8/steelarc-integration/1.0.0/m/s/-/dw/shop/v19_5";
-const client = new Shop.ShopApi.Client({
+
+console.log(Shop.ShopApi);
+const client = new Shop.ShopApi({
   baseUri: BASE_URI
 });
 
+// let test: Shop;
 before(() => {
-  chai.should();
   chai.use(chaiAsPromised);
 
   return client.initializeMockService();
@@ -24,7 +25,7 @@ before(() => {
 
 describe("Shop client integration GET tests", () => {
   it("Throws error calling GET with no token", () => {
-    const newLocalClient = new Shop.ShopApi.Client({
+    const newLocalClient = new Shop.ShopApi({
       baseUri: BASE_URI
     });
 
@@ -62,7 +63,7 @@ describe("Shop client integration GET tests", () => {
 
 describe("Shop client integration PUT tests", () => {
   it("Throws error calling PUT with no token", () => {
-    const newLocalClient = new Shop.ShopApi.Client({
+    const newLocalClient = new Shop.ShopApi({
       baseUri: BASE_URI
     });
 
@@ -95,7 +96,7 @@ describe("Shop client integration PUT tests", () => {
 
 describe("Shop client integration PATCH tests", () => {
   it("Throws error calling PATCH with no token", () => {
-    const newLocalClient = new Shop.ShopApi.Client({
+    const newLocalClient = new Shop.ShopApi({
       baseUri: BASE_URI
     });
 
@@ -123,7 +124,7 @@ describe("Shop client integration PATCH tests", () => {
 
 describe("Shop client integration DELETE tests", () => {
   it("Throws error calling DELETE with no token", () => {
-    const newLocalClient = new Shop.ShopApi.Client({
+    const newLocalClient = new Shop.ShopApi({
       baseUri: BASE_URI
     });
 
@@ -139,7 +140,7 @@ describe("Shop client integration DELETE tests", () => {
 
 describe("Shop client integration POST tests", () => {
   it("Throws error calling POST with no token", () => {
-    const newLocalClient = new Shop.ShopApi.Client({
+    const newLocalClient = new Shop.ShopApi({
       baseUri: BASE_URI
     });
 


### PR DESCRIPTION
This allows you to reference the class directly instead of through a client object

Example:
```
let client = new Product.ShopperProduct({})
```
instead of 
```
let client = new Product.ShopperProduct.Client({});
```