### PR TITLE
Add two overload functions per function for Response and DTO return types

### DIFF
--- a/packages/core/src/base/resource.ts
+++ b/packages/core/src/base/resource.ts
@@ -43,7 +43,9 @@ export class Resource {
       this.pathParameters
     );
 
-    const queryString = qs.stringify(this.queryParameters, { arrayFormat: "repeat" });
+    const queryString = qs.stringify(this.queryParameters, {
+      arrayFormat: "repeat"
+    });
 
     return `${renderedBaseUri}${renderedPath}${
       queryString ? "?" : ""

--- a/packages/generator/src/templateHelpers.ts
+++ b/packages/generator/src/templateHelpers.ts
@@ -157,8 +157,7 @@ const getPayloadResponses = function(operation: any): model.domain.Response[] {
 
 export const getReturnPayloadType = function(operation: any): string {
   const okResponses = getPayloadResponses(operation);
-  // Always at least provide Response as an option
-  const dataTypes: string[] = ["Response"];
+  const dataTypes: string[] = [];
   okResponses.forEach(res => {
     if (res.payloads.length > 0) {
       dataTypes.push(

--- a/packages/generator/templates/helpers.ts.hbs
+++ b/packages/generator/templates/helpers.ts.hbs
@@ -28,10 +28,9 @@ export async function getShopperToken (
 ): Promise<ShopperToken>{
     let client = new sdk.{{shopperAuthClient}}.Client(clientConfig);
 
-    let response = (await client.{{shopperAuthApi}}({
-        rawResponse: true,
+    const response: Response = (await client.{{shopperAuthApi}}({
         body: body
-    })) as Response;
+    }, true));
     if (!response.ok) {
         throw new ResponseError(response);
     }
@@ -63,15 +62,13 @@ export async function getAuthToken<T extends typeof shopperAuthApi>(
     }
     });
 
-    options.rawResponse = true;
-
     // At some point this should go through the same stripping as everything else.
     //  Should be part of the global config story
     delete options.parameters.shortCode;
 
-    let response = await client.authorizeCustomer(options) as Response;
+    const response: Response = await client.authorizeCustomer(options, true);
     if (!response.ok) {
-    throw new Error(`${response.status}: ${response.statusText}`)
+        throw new Error(`${response.status}: ${response.statusText}`)
     }
     return new ShopperToken(stripBearer(response.headers.get("Authorization")));
 }

--- a/packages/generator/templates/operations.ts.hbs
+++ b/packages/generator/templates/operations.ts.hbs
@@ -2,10 +2,13 @@
   {{#each operations}}
     /**
     * {{description}}
+    * 
+    * If you would like to get a raw Response object use the other {{name}} function.
+    * 
+    * @returns A promise of type {{getReturnPayloadType .}}
     */
     {{name}}(
       options{{#or (is method "get") (is method "delete")}}?{{/or}}: {
-        rawResponse?: boolean,
         parameters?: {
           {{#each ../parameters}}
           {{! common parameters can be configured at the client level and therefore are not required }}
@@ -18,7 +21,49 @@
         headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}}, 
         body: {{default request.payloads.[0].schema.inherits.[0].linkTarget.name "object"}}{{/or}}
       }
-    ): Promise<{{getReturnPayloadType .}}> {
+    ): Promise<{{getReturnPayloadType .}}>;
+
+    /**
+    * {{description}}
+    *
+    * @returns A promise of type Response if rawResponse is true, a promise of {{getReturnPayloadType .}} otherwise
+    */
+    {{name}}<T extends boolean>(
+      options{{#or (is method "get") (is method "delete")}}?{{/or}}: {
+        parameters?: {
+          {{#each ../parameters}}
+          {{! common parameters can be configured at the client level and therefore are not required }}
+          {{name}}{{#if (isCommonPathParameter name)}}?{{/if}}: any
+          {{/each}}
+          {{#each request/queryParameters}}
+          {{name}}{{#if (or (not (is required "true")) (isCommonQueryParameter name))}}?{{/if}}: any
+          {{/each}}
+        },
+        headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}}, 
+        body: {{default request.payloads.[0].schema.inherits.[0].linkTarget.name "object"}}{{/or}}
+      },
+      rawResponse?: T
+    ): Promise<T extends true ? Response : {{getReturnPayloadType .}}>;
+
+    /**
+    * {{description}}
+    */
+    {{name}}(
+      options{{#or (is method "get") (is method "delete")}}?{{/or}}: {
+        parameters?: {
+          {{#each ../parameters}}
+          {{! common parameters can be configured at the client level and therefore are not required }}
+          {{name}}{{#if (isCommonPathParameter name)}}?{{/if}}: any
+          {{/each}}
+          {{#each request/queryParameters}}
+          {{name}}{{#if (or (not (is required "true")) (isCommonQueryParameter name))}}?{{/if}}: any
+          {{/each}}
+        },
+        headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}}, 
+        body: {{default request.payloads.[0].schema.inherits.[0].linkTarget.name "object"}}{{/or}}
+      },
+      rawResponse?: boolean,
+    ): Promise<Response | {{getReturnPayloadType .}}> {
     
       const parameters = (options && options.parameters) ? options.parameters : {};
       
@@ -45,7 +90,7 @@
       // @ts-ignore
       return StaticClient.{{method}}({
         client: this,
-        rawResponse: (options || {}).rawResponse,
+        rawResponse: rawResponse,
         path: "{{../path}}",
         pathParameters: pathParameters,
         queryParameters: queryParameters,

--- a/packages/generator/templates/operations.ts.hbs
+++ b/packages/generator/templates/operations.ts.hbs
@@ -26,7 +26,7 @@
     /**
     * {{description}}
     *
-    * @returns A promise of type Response if rawResponse is true, a promise of {{getReturnPayloadType .}} otherwise
+    * @returns A promise of type Response if rawResponse is true, a promise of type {{getReturnPayloadType .}} otherwise
     */
     {{name}}<T extends boolean>(
       options{{#or (is method "get") (is method "delete")}}?{{/or}}: {

--- a/packages/generator/test/template-helpers.test.ts
+++ b/packages/generator/test/template-helpers.test.ts
@@ -342,34 +342,34 @@ describe("Template helper, response item type tests", () => {
     operation.withResponses([response]);
   });
 
-  it("Returns 'Response | Object' on unknown datatype", () => {
+  it("Returns 'Object' on unknown datatype", () => {
     const response = operation.responses[0];
     response.payloads[0].schema.withName("schema");
     response.withStatusCode("200");
-    expect(getReturnPayloadType(operation)).to.equal("Response | Object");
+    expect(getReturnPayloadType(operation)).to.equal("Object");
   });
 
   it("Returns 'defined_type' on defined_type datatype", () => {
     const response: model.domain.Response = operation.responses[0];
     response.withStatusCode("200");
     response.payloads[0].schema.withName("DefinedType");
-    expect(getReturnPayloadType(operation)).to.equal("Response | DefinedType");
+    expect(getReturnPayloadType(operation)).to.equal("DefinedType");
   });
 
-  it("Returns 'Response | void' on defined_type datatype, but with statusCode as 500", () => {
+  it("Returns 'void' on defined_type datatype, but with statusCode as 500", () => {
     const response: model.domain.Response = operation.responses[0];
     response.withStatusCode("500");
     response.payloads[0].schema.withName("DefinedType");
-    expect(getReturnPayloadType(operation)).to.equal("Response | void");
+    expect(getReturnPayloadType(operation)).to.equal("void");
   });
 
-  it("Returns 'Response | void' without responses", () => {
+  it("Returns 'void' without responses", () => {
     operation.withResponses([]);
-    expect(getReturnPayloadType(operation)).to.equal("Response | void");
+    expect(getReturnPayloadType(operation)).to.equal("void");
   });
 
-  it("Returns 'Response | void' datatype, with response array but with no response codes", () => {
-    expect(getReturnPayloadType(operation)).to.equal("Response | void");
+  it("Returns 'void' datatype, with response array but with no response codes", () => {
+    expect(getReturnPayloadType(operation)).to.equal("void");
   });
 });
 

--- a/packages/generator/test_integration/site_integration.test.ts
+++ b/packages/generator/test_integration/site_integration.test.ts
@@ -80,13 +80,13 @@ describe("Shop client integration PUT tests", () => {
   it("Returns object calling PUT with valid token and request body", () => {
     return client
       .updateCustomerPassword({
-        rawResponse: true,
         body: {
           // eslint-disable-next-line @typescript-eslint/camelcase
           current_password: "Current password",
           password: ""
         }
-      })
+      },
+      true)
       .then(res => {
         return expect((res as Response).ok).is.true;
       });
@@ -132,7 +132,7 @@ describe("Shop client integration DELETE tests", () => {
 
   it("Returns object calling DELETE with valid token", () => {
     return client
-      .deleteSite({ rawResponse: true })
+      .deleteSite({}, true)
       .then(res => expect((res as Response).ok).to.be.true);
   });
 });


### PR DESCRIPTION
Resolves the return type ambiguity by overloading functions. Each function is overloaded by two functions. One returns the DTO when no value for rawResponse is provided. The other returns the DTO or Response object based on the value of rawResponse.

rawResponse is now its own param instead of a field on options object which it was before.

Implementing this solution increased the size of our SDK by ~75KB (Total unpacked SDK size before the change was 1.6MB). I also added extra tsdocs which further increased the size by ~130KB.