### PR TITLE
Refactor code to get property data types in dtos

### DIFF
--- a/packages/generator/src/renderer.ts
+++ b/packages/generator/src/renderer.ts
@@ -17,12 +17,7 @@ import {
 
 import {
   getBaseUri,
-  isDefinedProperty,
-  getDataType,
-  isPrimitiveProperty,
-  isArrayProperty,
-  isObjectProperty,
-  getArrayElementTypeProperty,
+  getPropertyDataType,
   getReturnPayloadType,
   getValue,
   isAdditionalPropertiesAllowed,
@@ -301,19 +296,9 @@ Handlebars.registerHelper("isCommonQueryParameter", isCommonQueryParameter);
 
 Handlebars.registerHelper("isCommonPathParameter", isCommonPathParameter);
 
-Handlebars.registerHelper("isDefinedProperty", isDefinedProperty);
-
-Handlebars.registerHelper("getDataType", getDataType);
-
-Handlebars.registerHelper("isPrimitive", isPrimitiveProperty);
-
-Handlebars.registerHelper("isArrayProperty", isArrayProperty);
-
-Handlebars.registerHelper("isObjectProperty", isObjectProperty);
+Handlebars.registerHelper("getPropertyDataType", getPropertyDataType);
 
 Handlebars.registerHelper("isTypeDefinition", isTypeDefinition);
-
-Handlebars.registerHelper("getArrayElementType", getArrayElementTypeProperty);
 
 Handlebars.registerHelper("getReturnPayloadType", getReturnPayloadType);
 

--- a/packages/generator/templates/dtoPartial.ts.hbs
+++ b/packages/generator/templates/dtoPartial.ts.hbs
@@ -1,9 +1,9 @@
 {
 {{#each (getProperties typeDto)}}
 {{#if (isRequiredProperty .)}}
-    {{{getValue name}}}: {{#or (eq (getDataType .) "object")}}{{> dtoPartial typeDto=range }}{{else}}{{{getDataType .}}}{{/or}};
+    {{{getValue name}}}: {{#or (eq (getPropertyDataType .) "object")}}{{> dtoPartial typeDto=range }}{{else}}{{{getPropertyDataType .}}}{{/or}};
 {{else if (isOptionalProperty .)}}
-    {{{getValue name}}}?: {{#or (eq (getDataType .) "object")}}{{> dtoPartial typeDto=range }}{{else}}{{{getDataType .}}}{{/or}};
+    {{{getValue name}}}?: {{#or (eq (getPropertyDataType .) "object")}}{{> dtoPartial typeDto=range }}{{else}}{{{getPropertyDataType .}}}{{/or}};
 {{/if}}
 {{/each}}
 }


### PR DESCRIPTION
Code to get data types is refactored to 
- use amf classes instead of any
- cleaned and  organized
- fixed unit tests
- removed unused functions related to data types
- compared the rendered files with my changes - no diffs founds except the below one which is actually a fix

```
export type QueryT = {
    boolQuery?: {
    must?: Array<any>;
    mustNot?: Array<any>;
    should?: Array<any>;
}& { [key: string]: any }
;
    filteredQuery?: {
    filter: any;
    query: any;
}& { [key: string]: any }
;
........
```
is now rendered as

```
export type QueryT = {
    boolQuery?: BoolQueryT;
    filteredQuery?: FilteredQueryT;
    matchAllQuery?: MatchAllQueryT;
    nestedQuery?: NestedQueryT;
    termQuery?: TermQueryT;
    textQuery?: TextQueryT;
}& { [key: string]: any }
```