### PR TITLE
Render data types of parameters for endpoint operations

### DIFF
--- a/packages/generator/src/renderer.ts
+++ b/packages/generator/src/renderer.ts
@@ -18,6 +18,7 @@ import {
 import {
   getBaseUri,
   getPropertyDataType,
+  getParameterDataType,
   getReturnPayloadType,
   getValue,
   isAdditionalPropertiesAllowed,
@@ -297,6 +298,8 @@ Handlebars.registerHelper("isCommonQueryParameter", isCommonQueryParameter);
 Handlebars.registerHelper("isCommonPathParameter", isCommonPathParameter);
 
 Handlebars.registerHelper("getPropertyDataType", getPropertyDataType);
+
+Handlebars.registerHelper("getParameterDataType", getParameterDataType);
 
 Handlebars.registerHelper("isTypeDefinition", isTypeDefinition);
 

--- a/packages/generator/src/templateHelpers.ts
+++ b/packages/generator/src/templateHelpers.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { model } from "amf-client-js";
-import _ from "lodash";
 import { WebApiBaseUnitWithEncodesModel } from "webapi-parser";
 
 import { commonParameterPositions } from "@commerce-apps/core";
@@ -237,6 +236,20 @@ export const getPropertyDataType = function(
 ): string {
   if (property != null && property.range != null) {
     return getDataType(property.range);
+  }
+  return DEFAULT_DATA_TYPE;
+};
+
+/**
+ * Get data type of a parameter
+ * @param param instance of model.domain.Parameter
+ * @returns data type if defined in the parameter otherwise returns a default type
+ */
+export const getParameterDataType = function(
+  param: model.domain.Parameter
+): string {
+  if (param != null && param.schema != null) {
+    return getDataType(param.schema);
   }
   return DEFAULT_DATA_TYPE;
 };

--- a/packages/generator/templates/operations.ts.hbs
+++ b/packages/generator/templates/operations.ts.hbs
@@ -12,10 +12,10 @@
         parameters?: {
           {{#each ../parameters}}
           {{! common parameters can be configured at the client level and therefore are not required }}
-          {{name}}{{#if (isCommonPathParameter name)}}?{{/if}}: any
+          {{name}}{{#if (isCommonPathParameter name)}}?{{/if}}: {{{ getParameterDataType .}}}
           {{/each}}
           {{#each request/queryParameters}}
-          {{name}}{{#if (or (not (is required "true")) (isCommonQueryParameter name))}}?{{/if}}: any
+          {{name}}{{#if (or (not (is required "true")) (isCommonQueryParameter name))}}?{{/if}}: {{{ getParameterDataType .}}}
           {{/each}}
         },
         headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}}, 
@@ -33,10 +33,10 @@
         parameters?: {
           {{#each ../parameters}}
           {{! common parameters can be configured at the client level and therefore are not required }}
-          {{name}}{{#if (isCommonPathParameter name)}}?{{/if}}: any
+          {{name}}{{#if (isCommonPathParameter name)}}?{{/if}}: {{{ getParameterDataType .}}}
           {{/each}}
           {{#each request/queryParameters}}
-          {{name}}{{#if (or (not (is required "true")) (isCommonQueryParameter name))}}?{{/if}}: any
+          {{name}}{{#if (or (not (is required "true")) (isCommonQueryParameter name))}}?{{/if}}: {{{ getParameterDataType .}}}
           {{/each}}
         },
         headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}}, 
@@ -53,10 +53,10 @@
         parameters?: {
           {{#each ../parameters}}
           {{! common parameters can be configured at the client level and therefore are not required }}
-          {{name}}{{#if (isCommonPathParameter name)}}?{{/if}}: any
+          {{name}}{{#if (isCommonPathParameter name)}}?{{/if}}: {{{ getParameterDataType .}}}
           {{/each}}
           {{#each request/queryParameters}}
-          {{name}}{{#if (or (not (is required "true")) (isCommonQueryParameter name))}}?{{/if}}: any
+          {{name}}{{#if (or (not (is required "true")) (isCommonQueryParameter name))}}?{{/if}}: {{{ getParameterDataType .}}}
           {{/each}}
         },
         headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}}, 

--- a/packages/generator/test/template-helpers.test.ts
+++ b/packages/generator/test/template-helpers.test.ts
@@ -13,10 +13,10 @@ import {
   isOptionalProperty,
   isRequiredProperty,
   isAdditionalPropertiesAllowed,
-  getProperties
+  getProperties,
+  getParameterDataType
 } from "../src/templateHelpers";
 
-import _ from "lodash";
 import { assert, expect } from "chai";
 import { model, AMF } from "amf-client-js";
 
@@ -184,6 +184,33 @@ describe("Template helper datatype tests", () => {
     property.withRange(new model.domain.PropertyShape());
 
     expect(getPropertyDataType(property)).to.equal("any");
+  });
+});
+
+describe("Test retrieval of data types for endpoint parameters", () => {
+  before(() => {
+    return AMF.init();
+  });
+  it("Returns 'any' on undefined parameter", () => {
+    expect(getParameterDataType(undefined)).to.equal("any");
+  });
+
+  it("Returns 'any' on null parameter", () => {
+    expect(getParameterDataType(null)).to.equal("any");
+  });
+
+  it("Returns 'any' on parameter with undefined schema", () => {
+    expect(getParameterDataType(new model.domain.Parameter())).to.equal("any");
+  });
+
+  /**
+   * Note: Test cases to get various data types (arrays, objects, etc) are already covered as part of the property data type tests
+   */
+  it("Returns 'boolean' on boolean dataType", () => {
+    const param: model.domain.Parameter = new model.domain.Parameter();
+    param.withSchema(getScalarType("http://www.w3.org/2001/XMLSchema#boolean"));
+
+    expect(getParameterDataType(param)).to.equal("boolean");
   });
 });
 


### PR DESCRIPTION
Sample of rendered code with parameter ttpes
```
productSearch(
        options?: {
          parameters?: {
            organizationId?: string
            siteId?: string
            q?: string
            refine?: Array<string>
            sort?: string
            currency?: string
            locale?: string
            offset?: number
            limit?: number
          },
          headers?: { [key: string]: string }
        }
      ): Promise<ProductSearchResultT>;
  ```