### PR TITLE
Render data type for request body

### DIFF
--- a/packages/generator/src/renderer.ts
+++ b/packages/generator/src/renderer.ts
@@ -19,6 +19,7 @@ import {
   getBaseUri,
   getPropertyDataType,
   getParameterDataType,
+  getRequestPayloadType,
   getReturnPayloadType,
   getValue,
   isAdditionalPropertiesAllowed,
@@ -301,6 +302,8 @@ Handlebars.registerHelper("isCommonPathParameter", isCommonPathParameter);
 Handlebars.registerHelper("getPropertyDataType", getPropertyDataType);
 
 Handlebars.registerHelper("getParameterDataType", getParameterDataType);
+
+Handlebars.registerHelper("getRequestPayloadType", getRequestPayloadType);
 
 Handlebars.registerHelper("isTypeDefinition", isTypeDefinition);
 

--- a/packages/generator/src/templateHelpers.ts
+++ b/packages/generator/src/templateHelpers.ts
@@ -255,6 +255,37 @@ export const getParameterDataType = function(
   return DEFAULT_DATA_TYPE;
 };
 
+const getPayloadType = function(schema: model.domain.Shape): string {
+  const name = schema.name.value();
+  if (name != null) {
+    if (name === "schema") {
+      return OBJECT_DATA_TYPE;
+    } else {
+      return name + "T";
+    }
+  }
+  return OBJECT_DATA_TYPE;
+};
+
+export const getRequestPayloadType = function(
+  request: model.domain.Request
+): string {
+  if (
+    request != null &&
+    request.payloads != null &&
+    request.payloads.length > 0
+  ) {
+    const payloadSchema: model.domain.Shape = request.payloads[0].schema;
+    if (payloadSchema instanceof model.domain.ArrayShape) {
+      return ARRAY_DATA_TYPE.concat("<")
+        .concat(getPayloadType(payloadSchema.items))
+        .concat(">");
+    }
+    return getPayloadType(payloadSchema);
+  }
+  return OBJECT_DATA_TYPE;
+};
+
 export const getValue = function(name: any): string {
   if (name !== undefined && name.value) {
     return name.value();

--- a/packages/generator/src/templateHelpers.ts
+++ b/packages/generator/src/templateHelpers.ts
@@ -257,16 +257,21 @@ export const getParameterDataType = function(
 
 const getPayloadType = function(schema: model.domain.Shape): string {
   const name = schema.name.value();
-  if (name != null) {
-    if (name === "schema") {
-      return OBJECT_DATA_TYPE;
-    } else {
-      return name + "T";
-    }
+  if (name == null) {
+    return OBJECT_DATA_TYPE;
   }
-  return OBJECT_DATA_TYPE;
+  if (name === "schema") {
+    return OBJECT_DATA_TYPE;
+  } else {
+    return name + "T";
+  }
 };
 
+/**
+ * Get type of the request body
+ * @param request AMF model of tge request
+ * @returns Type of the request body
+ */
 export const getRequestPayloadType = function(
   request: model.domain.Request
 ): string {

--- a/packages/generator/templates/operations.ts.hbs
+++ b/packages/generator/templates/operations.ts.hbs
@@ -18,8 +18,8 @@
           {{name}}{{#if (or (not (is required "true")) (isCommonQueryParameter name))}}?{{/if}}: {{{ getParameterDataType .}}}
           {{/each}}
         },
-        headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}}, 
-        body: {{default request.payloads.[0].schema.inherits.[0].linkTarget.name "object"}}{{/or}}
+        headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}},
+        body: {{{getRequestPayloadType request}}}{{/or}}
       }
     ): Promise<{{getReturnPayloadType .}}>;
 
@@ -40,7 +40,7 @@
           {{/each}}
         },
         headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}}, 
-        body: {{default request.payloads.[0].schema.inherits.[0].linkTarget.name "object"}}{{/or}}
+        body: {{{getRequestPayloadType request}}}{{/or}}
       },
       rawResponse?: T
     ): Promise<T extends true ? Response : {{getReturnPayloadType .}}>;
@@ -60,7 +60,7 @@
           {{/each}}
         },
         headers?: { [key: string]: string }{{#or (is method "patch") (is method "post") (is method "put")}}, 
-        body: {{default request.payloads.[0].schema.inherits.[0].linkTarget.name "object"}}{{/or}}
+        body: {{{getRequestPayloadType request}}}{{/or}}
       },
       rawResponse?: boolean,
     ): Promise<Response | {{getReturnPayloadType .}}> {

--- a/packages/generator/test_integration/site-integration.test.ts
+++ b/packages/generator/test_integration/site-integration.test.ts
@@ -220,7 +220,8 @@ describe("Test that request body has data type defined", () => {
     >[0];
     type reqBodyType = funcParam["body"];
     let temp: reqBodyType;
-    //verify that siteId is of type string
+    //verify that temp is of type search_request
+    // eslint-disable-next-line @typescript-eslint/camelcase
     assert<IsExact<typeof temp, Shop.ShopApi.search_request>>(true);
   });
 });

--- a/packages/generator/test_integration/site-integration.test.ts
+++ b/packages/generator/test_integration/site-integration.test.ts
@@ -9,6 +9,7 @@ import { Shop } from "../dist";
 import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { assert, IsExact } from "conditional-type-checks";
+
 const BASE_URI =
   "https://anypoint.mulesoft.com/mocking/api/v1/sources/exchange/assets/893f605e-10e2-423a-bdb4-f952f56eb6d8/steelarc-integration/1.0.0/m/s/-/dw/shop/v19_5";
 
@@ -209,5 +210,17 @@ describe("Test that function parameters have data types", () => {
     let temp: siteIdType;
     //verify that siteId is of type string
     assert<IsExact<typeof temp, string>>(true);
+  });
+});
+
+describe("Test that request body has data type defined", () => {
+  it("Test that function parameters have data types", () => {
+    type funcParam = Parameters<
+      typeof Shop.ShopApi.prototype.searchProducts
+    >[0];
+    type reqBodyType = funcParam["body"];
+    let temp: reqBodyType;
+    //verify that siteId is of type string
+    assert<IsExact<typeof temp, Shop.ShopApi.search_request>>(true);
   });
 });


### PR DESCRIPTION
Sample rendered code
```typescript
promotionsSearch(
        options: {
          parameters?: {
            organizationId?: string
            siteId?: string
          },
          headers?: { [key: string]: string },
          body: SearchRequestT
        }
      ): Promise<PromotionSearchResultT>;

 addItemToBasket<T extends boolean>(
        options: {
          parameters?: {
            organizationId?: string
            basketId: string
            siteId?: string
          },
          headers?: { [key: string]: string }, 
          body: Array<ProductItemT>
        },
        rawResponse?: T
      ): Promise<T extends true ? Response : BasketT>;
```
  