### PR TITLE
Add example client instantiation to APICLIENTS.md

### DIFF
--- a/packages/generator/APICLIENTS.md
+++ b/packages/generator/APICLIENTS.md
@@ -1,85 +1,355 @@
-# Included Apis
-Each of the following APIs has a corresponding client in the SDK which can be instantiated to communicate with that API. See the [README](./README.md#usage) for examples on how to instantiate, configure and use clients.
+# Included APIs
+
+Each of the following APIs has a corresponding client in the SDK which can be instantiated to communicate with that API.
 
 ## AI
-#### [Einstein Recommendations](https://developer.commercecloud.com/s/api-details/a003k00000UI4hPAAT)
-*Get Einstein recommendations and send activities to Einstein engine.*<br />
-_______________________________________________________________________
+
+### [Einstein Recommendations](https://developer.commercecloud.com/s/api-details/a003k00000UI4hPAAT)
+
+*Get Einstein recommendations and send activities to Einstein engine.*
+
+To instantiate a client:
+
+```typescript
+import { Ai, ClientConfig } from "commerce-sdk";
+// or
+const { Ai, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const einsteinQuickStartGuideClient = new Ai.EinsteinQuickStartGuide(config);
+```
 
 ## CDN
-#### [CDN Zones](https://developer.commercecloud.com/s/api-details/a003k00000UIKk2AAH)
-*Extend your eCDN beyond Business Manager configuration.*<br />
-_______________________________________________________________________
+
+### [CDN Zones](https://developer.commercecloud.com/s/api-details/a003k00000UIKk2AAH)
+
+*Extend your eCDN beyond Business Manager configuration.*
+
+To instantiate a client:
+
+```typescript
+import { Cdn, ClientConfig } from "commerce-sdk";
+// or
+const { Cdn, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const cdnZonesClient = new Cdn.CdnZones(config);
+```
 
 ## Checkout
-#### [Orders](https://developer.commercecloud.com/s/api-details/a003k00000UHvp4AAD)
-**Mule App Version** 1.0.12<br />
-*Manage order status and order payment status.*<br />
-#### [Shopper Baskets](https://developer.commercecloud.com/s/api-details/a003k00000UHvpEAAT)
-**Mule App Version** 0.0.34<br />
-*Build a checkout experience.*<br />
-#### [Shopper Orders](https://developer.commercecloud.com/s/api-details/a003k00000UHvpFAAT)
-**Mule App Version** 0.0.21<br />
-*Finish the shopper checkout experience resulting in an order.*<br />
-_______________________________________________________________________
+
+### [Orders](https://developer.commercecloud.com/s/api-details/a003k00000UHvp4AAD)
+
+*Manage order status and order payment status.*
+
+To instantiate a client:
+
+```typescript
+import { Checkout, ClientConfig } from "commerce-sdk";
+// or
+const { Checkout, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const ordersClient = new Checkout.Orders(config);
+```
+
+**Mule App Version:** 1.0.12
+
+### [Shopper Baskets](https://developer.commercecloud.com/s/api-details/a003k00000UHvpEAAT)
+
+*Build a checkout experience.*
+
+To instantiate a client:
+
+```typescript
+import { Checkout, ClientConfig } from "commerce-sdk";
+// or
+const { Checkout, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const shopperBasketsClient = new Checkout.ShopperBaskets(config);
+```
+
+**Mule App Version:** 0.0.34
+
+### [Shopper Orders](https://developer.commercecloud.com/s/api-details/a003k00000UHvpFAAT)
+
+*Finish the shopper checkout experience resulting in an order.*
+
+To instantiate a client:
+
+```typescript
+import { Checkout, ClientConfig } from "commerce-sdk";
+// or
+const { Checkout, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const shopperOrdersClient = new Checkout.ShopperOrders(config);
+```
+
+**Mule App Version:** 0.0.21
 
 ## Customer
-#### [Customers](https://developer.commercecloud.com/s/api-details/a003k00000UHvouAAD)
-**Mule App Version** 0.0.10<br />
-*Manage customer lists, and search and manage customer groups.*<br />
-#### [Shopper Customers](https://developer.commercecloud.com/s/api-details/a003k00000UHvpJAAT)
-**Mule App Version** 0.0.17<br />
-*Let customers log in and manage their profiles and product lists.*<br />
-_______________________________________________________________________
+
+### [Customers](https://developer.commercecloud.com/s/api-details/a003k00000UHvouAAD)
+
+*Manage customer lists, and search and manage customer groups.*
+
+To instantiate a client:
+
+```typescript
+import { Customer, ClientConfig } from "commerce-sdk";
+// or
+const { Customer, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const customersClient = new Customer.Customers(config);
+```
+
+**Mule App Version:** 0.0.10
+
+### [Shopper Customers](https://developer.commercecloud.com/s/api-details/a003k00000UHvpJAAT)
+
+*Let customers log in and manage their profiles and product lists.*
+
+To instantiate a client:
+
+```typescript
+import { Customer, ClientConfig } from "commerce-sdk";
+// or
+const { Customer, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const shopperCustomersClient = new Customer.ShopperCustomers(config);
+```
+
+**Mule App Version:** 0.0.17
 
 ## Pricing
-#### [Assignments](https://developer.commercecloud.com/s/api-details/a003k00000UHvoaAAD)
-**Mule App Version** 1.0.12<br />
-*Enable merchandisers to search for assignments.*<br />
-#### [Campaigns](https://developer.commercecloud.com/s/api-details/a003k00000UHvobAAD)
-**Mule App Version** 1.0.15<br />
-*Create, update, and manage campaigns.*<br />
-#### [Coupons](https://developer.commercecloud.com/s/api-details/a003k00000UHvopAAD)
-**Mule App Version** 1.0.15<br />
-*Create, update, read, search for, and manage coupons.*<br />
-#### [Gift Certificates](https://developer.commercecloud.com/s/api-details/a003k00000UHvozAAD)
-**Mule App Version** 1.0.17<br />
-*Create, get, and update gift certificates.*<br />
-#### [Promotions](https://developer.commercecloud.com/s/api-details/a003k00000UHvp9AAD)
-**Mule App Version** 1.0.12<br />
-*Create, get, and update promotions.*<br />
-#### [Shopper Gift Certificates](https://developer.commercecloud.com/s/api-details/a003k00000UHvogAAD)
-**Mule App Version** 1.0.6<br />
-*Obtain details about a gift certificate.*<br />
-#### [Shopper Promotions](https://developer.commercecloud.com/s/api-details/a003k00000UHvp5AAD)
-**Mule App Version** 1.0.15<br />
-*Obtain promotion details.*<br />
-#### [Source Code Groups](https://developer.commercecloud.com/s/api-details/a003k00000UHvpTAAT)
-**Mule App Version** 1.0.16<br />
-*Create, update, delete, and search for source code groups.*<br />
-_______________________________________________________________________
+
+### [Assignments](https://developer.commercecloud.com/s/api-details/a003k00000UHvoaAAD)
+
+*Enable merchandisers to search for assignments.*
+
+To instantiate a client:
+
+```typescript
+import { Pricing, ClientConfig } from "commerce-sdk";
+// or
+const { Pricing, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const assignmentsClient = new Pricing.Assignments(config);
+```
+
+**Mule App Version:** 1.0.12
+
+### [Campaigns](https://developer.commercecloud.com/s/api-details/a003k00000UHvobAAD)
+
+*Create, update, and manage campaigns.*
+
+To instantiate a client:
+
+```typescript
+import { Pricing, ClientConfig } from "commerce-sdk";
+// or
+const { Pricing, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const campaignsClient = new Pricing.Campaigns(config);
+```
+
+**Mule App Version:** 1.0.15
+
+### [Coupons](https://developer.commercecloud.com/s/api-details/a003k00000UHvopAAD)
+
+*Create, update, read, search for, and manage coupons.*
+
+To instantiate a client:
+
+```typescript
+import { Pricing, ClientConfig } from "commerce-sdk";
+// or
+const { Pricing, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const couponsClient = new Pricing.Coupons(config);
+```
+
+**Mule App Version:** 1.0.15
+
+### [Gift Certificates](https://developer.commercecloud.com/s/api-details/a003k00000UHvozAAD)
+
+*Create, get, and update gift certificates.*
+
+To instantiate a client:
+
+```typescript
+import { Pricing, ClientConfig } from "commerce-sdk";
+// or
+const { Pricing, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const giftCertificatesClient = new Pricing.GiftCertificates(config);
+```
+
+**Mule App Version:** 1.0.17
+
+### [Promotions](https://developer.commercecloud.com/s/api-details/a003k00000UHvp9AAD)
+
+*Create, get, and update promotions.*
+
+To instantiate a client:
+
+```typescript
+import { Pricing, ClientConfig } from "commerce-sdk";
+// or
+const { Pricing, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const promotionsClient = new Pricing.Promotions(config);
+```
+
+**Mule App Version:** 1.0.12
+
+### [Shopper Gift Certificates](https://developer.commercecloud.com/s/api-details/a003k00000UHvogAAD)
+
+*Obtain details about a gift certificate.*
+
+To instantiate a client:
+
+```typescript
+import { Pricing, ClientConfig } from "commerce-sdk";
+// or
+const { Pricing, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const shopperGiftCertificatesClient = new Pricing.ShopperGiftCertificates(config);
+```
+
+**Mule App Version:** 1.0.6
+
+### [Shopper Promotions](https://developer.commercecloud.com/s/api-details/a003k00000UHvp5AAD)
+
+*Obtain promotion details.*
+
+To instantiate a client:
+
+```typescript
+import { Pricing, ClientConfig } from "commerce-sdk";
+// or
+const { Pricing, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const shopperPromotionsClient = new Pricing.ShopperPromotions(config);
+```
+
+**Mule App Version:** 1.0.15
+
+### [Source Code Groups](https://developer.commercecloud.com/s/api-details/a003k00000UHvpTAAT)
+
+*Create, update, delete, and search for source code groups.*
+
+To instantiate a client:
+
+```typescript
+import { Pricing, ClientConfig } from "commerce-sdk";
+// or
+const { Pricing, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const sourceCodeGroupsClient = new Pricing.SourceCodeGroups(config);
+```
+
+**Mule App Version:** 1.0.16
 
 ## Product
-#### [Catalogs](https://developer.commercecloud.com/s/api-details/a003k00000UHvofAAD)
-**Mule App Version** 0.0.11<br />
-*Create, manage, and search categories and catalogs within a merchandizing system.*<br />
-#### [Products](https://developer.commercecloud.com/s/api-details/a003k00000UHvovAAD)
-**Mule App Version** 0.0.10<br />
-*Create, manage, and search products within a merchandizing system.*<br />
-#### [Shopper Products](https://developer.commercecloud.com/s/api-details/a003k00000UHvp0AAD)
-**Mule App Version** 0.0.11<br />
-*Let customers view product and category details in shopping apps.*<br />
-_______________________________________________________________________
+
+### [Catalogs](https://developer.commercecloud.com/s/api-details/a003k00000UHvofAAD)
+
+*Create, manage, and search categories and catalogs within a merchandizing system.*
+
+To instantiate a client:
+
+```typescript
+import { Product, ClientConfig } from "commerce-sdk";
+// or
+const { Product, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const catalogsClient = new Product.Catalogs(config);
+```
+
+**Mule App Version:** 0.0.11
+
+### [Products](https://developer.commercecloud.com/s/api-details/a003k00000UHvovAAD)
+
+*Create, manage, and search products within a merchandizing system.*
+
+To instantiate a client:
+
+```typescript
+import { Product, ClientConfig } from "commerce-sdk";
+// or
+const { Product, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const productsClient = new Product.Products(config);
+```
+
+**Mule App Version:** 0.0.10
+
+### [Shopper Products](https://developer.commercecloud.com/s/api-details/a003k00000UHvp0AAD)
+
+*Let customers view product and category details in shopping apps.*
+
+To instantiate a client:
+
+```typescript
+import { Product, ClientConfig } from "commerce-sdk";
+// or
+const { Product, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const shopperProductsClient = new Product.ShopperProducts(config);
+```
+
+**Mule App Version:** 0.0.11
 
 ## Search
-#### [Shopper Search](https://developer.commercecloud.com/s/api-details/a003k00000UHwuFAAT)
-**Mule App Version** 1.0.10<br />
-*Perform product search and provide search suggestions.*<br />
-_______________________________________________________________________
+
+### [Shopper Search](https://developer.commercecloud.com/s/api-details/a003k00000UHwuFAAT)
+
+*Perform product search and provide search suggestions.*
+
+To instantiate a client:
+
+```typescript
+import { Search, ClientConfig } from "commerce-sdk";
+// or
+const { Search, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const shopperSearchClient = new Search.ShopperSearch(config);
+```
+
+**Mule App Version:** 1.0.10
 
 ## Seller
-#### [Shopper Stores](https://developer.commercecloud.com/s/api-details/a003k00000UHwuPAAT)
-**Mule App Version** 1.0.5<br />
-*Search for a specific store or stores in an area.*<br />
-_______________________________________________________________________
 
+### [Shopper Stores](https://developer.commercecloud.com/s/api-details/a003k00000UHwuPAAT)
+
+*Search for a specific store or stores in an area.*
+
+To instantiate a client:
+
+```typescript
+import { Seller, ClientConfig } from "commerce-sdk";
+// or
+const { Seller, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const shopperStoresClient = new Seller.ShopperStores(config);
+```
+
+**Mule App Version:** 1.0.5

--- a/packages/generator/src/renderer.ts
+++ b/packages/generator/src/renderer.ts
@@ -81,7 +81,7 @@ const dtoTemplate = Handlebars.compile(
   fs.readFileSync(path.join(templateDirectory, "dto.ts.hbs"), "utf8")
 );
 
-const versionTemplate = Handlebars.compile(
+const apiClientsTemplate = Handlebars.compile(
   fs.readFileSync(path.join(templateDirectory, "apiclients.md.hbs"), "utf8")
 );
 
@@ -166,15 +166,8 @@ function createHelpers(config: any): string {
  * @param {RestApi[]} apis
  * @param dir Directory path to save the rendered file
  */
-export function createVersionFile(
-  apis: { [key: string]: RestApi[] },
-  dir: string
-): void {
-  fs.writeFileSync(
-    // Write to the directory with the API definitions
-    path.join(dir, "APICLIENTS.md"),
-    versionTemplate({ apis: sortApis(apis) })
-  );
+export function createApiClients(apis: { [key: string]: RestApi[] }): string {
+  return apiClientsTemplate({ apis: sortApis(apis) });
 }
 
 /**
@@ -276,18 +269,25 @@ export async function renderTemplates(config: any): Promise<void> {
     )
   );
 
-  //create index file that exports all the api families in the root
+  // Create files with static filenames
+
+  // Create index file that exports all the API families in the root
   fs.writeFileSync(
     path.join(config.renderDir, "index.ts"),
     createIndex(familyNames)
   );
 
+  // Create file that exports helper functions
   fs.writeFileSync(
     path.join(config.renderDir, "helpers.ts"),
     createHelpers(config)
   );
 
-  createVersionFile(apiFamilyRamlConfig, path.join(config.renderDir, ".."));
+  // Create file documenting available APIs
+  fs.writeFileSync(
+    path.join(config.renderDir, "..", "APICLIENTS.md"),
+    createApiClients(apiFamilyRamlConfig)
+  );
 }
 
 export function renderOperationList(allApis: {

--- a/packages/generator/src/renderer.ts
+++ b/packages/generator/src/renderer.ts
@@ -289,7 +289,7 @@ export async function renderTemplates(config: any): Promise<void> {
   // Create index file that exports all the API families in the root
   fs.writeFileSync(
     path.join(config.renderDir, "index.ts"),
-    createIndex([...apiFamilyMap.keys()])
+    createIndex([...apiFamilyMap.keys()].map(name => _.camelCase(name)))
   );
 
   // Create file that exports helper functions

--- a/packages/generator/src/renderer.ts
+++ b/packages/generator/src/renderer.ts
@@ -105,8 +105,7 @@ const dtoPartial = Handlebars.compile(
  * Sort API families and their APIs by name.
  */
 export function sortApis(apis: ApiClientsInfoT[]): void {
-  const compare = (a: string, b: string): number =>
-    a > b ? 1 : a < b ? -1 : 0;
+  const compare = (a: string, b: string): number => (a > b ? 1 : -1);
   // Sort API families
   apis.sort((a, b) => compare(a[0].family, b[0].family));
   // Sort APIs within each family

--- a/packages/generator/src/templateHelpers.ts
+++ b/packages/generator/src/templateHelpers.ts
@@ -9,6 +9,8 @@ import { WebApiBaseUnitWithEncodesModel } from "webapi-parser";
 
 import { commonParameterPositions } from "@commerce-apps/core";
 
+import _ from "lodash";
+
 import {
   PRIMITIVE_DATA_TYPE_MAP,
   DEFAULT_DATA_TYPE,
@@ -407,6 +409,21 @@ export const isAdditionalPropertiesAllowed = function(
   );
 };
 
-export const getObjectIdByAssetId = function(assetId: string) {
+export const getObjectIdByAssetId = function(assetId: string): string {
   return ASSET_OBJECT_MAP[assetId];
+};
+
+type NamedObject = { name: { value: () => string } };
+
+export const getName = function(obj: NamedObject): string {
+  return obj?.name?.value?.() || "";
+};
+
+export const getCamelCaseName = function(obj: NamedObject): string {
+  return _.camelCase(getName(obj));
+};
+
+export const getPascalCaseName = function(obj: NamedObject): string {
+  const name = getCamelCaseName(obj);
+  return name[0].toUpperCase() + name.slice(1);
 };

--- a/packages/generator/src/templateHelpers.ts
+++ b/packages/generator/src/templateHelpers.ts
@@ -413,7 +413,7 @@ export const getObjectIdByAssetId = function(assetId: string): string {
   return ASSET_OBJECT_MAP[assetId];
 };
 
-type NamedObject = { name: { value: () => string } };
+export type NamedObject = { name: { value: () => string } };
 
 export const getName = function(obj: NamedObject): string {
   return obj?.name?.value?.() || "";
@@ -425,5 +425,5 @@ export const getCamelCaseName = function(obj: NamedObject): string {
 
 export const getPascalCaseName = function(obj: NamedObject): string {
   const name = getCamelCaseName(obj);
-  return name[0].toUpperCase() + name.slice(1);
+  return name && name[0].toUpperCase() + name.slice(1);
 };

--- a/packages/generator/templates/apiclients.md.hbs
+++ b/packages/generator/templates/apiclients.md.hbs
@@ -1,17 +1,19 @@
-# Included Apis
-Each of the following APIs has a corresponding client in the SDK which can be instantiated to communicate with that API. See the [README](./README.md#usage) for examples on how to instantiate, configure and use clients.
+# Included APIs
 
+Each of the following APIs has a corresponding client in the SDK which can be instantiated to communicate with that API. See the [README](./README.md#usage) for examples on how to instantiate, configure and use clients.
 {{#eachInMap apis}}
+
 ## {{{key}}}
 {{#each value}}
-#### [{{{name}}}](https://developer.commercecloud.com/s/api-details/{{{getObjectIdByAssetId assetId}}})
+
+### [{{{name}}}](https://developer.commercecloud.com/s/api-details/{{{getObjectIdByAssetId assetId}}})
 {{#if version}}
-**Mule App Version** {{{version}}}<br />
+
+**Mule App Version:** {{{version}}}
 {{/if}}
 {{#if description}}
-*{{{description}}}*<br />
+
+*{{{description}}}*
 {{/if}}
 {{/each}}
-_______________________________________________________________________
-
 {{/eachInMap}}

--- a/packages/generator/templates/apiclients.md.hbs
+++ b/packages/generator/templates/apiclients.md.hbs
@@ -1,19 +1,30 @@
 # Included APIs
 
-Each of the following APIs has a corresponding client in the SDK which can be instantiated to communicate with that API. See the [README](./README.md#usage) for examples on how to instantiate, configure and use clients.
-{{#eachInMap apis}}
+Each of the following APIs has a corresponding client in the SDK which can be instantiated to communicate with that API.
+{{#each apis}}
 
-## {{{key}}}
-{{#each value}}
+## {{{this.0.family}}}
+{{#each this}}
 
-### [{{{name}}}](https://developer.commercecloud.com/s/api-details/{{{getObjectIdByAssetId assetId}}})
-{{#if version}}
+### [{{{config.name}}}](https://developer.commercecloud.com/s/api-details/{{{getObjectIdByAssetId config.assetId}}})
+{{#if config.description}}
 
-**Mule App Version:** {{{version}}}
+*{{{config.description}}}*
 {{/if}}
-{{#if description}}
 
-*{{{description}}}*
+To instantiate a client:
+
+```typescript
+import { {{{pascalcase family}}}, ClientConfig } from "commerce-sdk";
+// or
+const { {{{pascalcase family}}}, ClientConfig } = require("commerce-sdk");
+
+const config: ClientConfig = { /* ... */ };
+const {{{getCamelCaseName model}}}Client = new {{{pascalcase family}}}.{{{getPascalCaseName model}}}(config);
+```
+{{#if config.version}}
+
+**Mule App Version:** {{{config.version}}}
 {{/if}}
 {{/each}}
-{{/eachInMap}}
+{{/each}}

--- a/packages/generator/test/template-helpers.test.ts
+++ b/packages/generator/test/template-helpers.test.ts
@@ -15,7 +15,11 @@ import {
   isAdditionalPropertiesAllowed,
   getProperties,
   getParameterDataType,
-  getRequestPayloadType
+  getRequestPayloadType,
+  NamedObject,
+  getName,
+  getCamelCaseName,
+  getPascalCaseName
 } from "../src/templateHelpers";
 
 import { assert, expect } from "chai";
@@ -562,5 +566,72 @@ describe("Template helper tests for getRequestPayloadType", () => {
         .concat("T")
         .concat(">")
     );
+  });
+});
+
+describe("Template helper tests for name helpers", () => {
+  const createNamedObject = (name: string): NamedObject => ({
+    name: { value: (): string => name }
+  });
+  const capitalStr = "Foo Bar";
+  const camelStr = "fooBar";
+  const pascalStr = "FooBar";
+  const snakeStr = "foo_bar";
+  const emptyStr = "";
+  const capitalObj = createNamedObject(capitalStr);
+  const camelObj = createNamedObject(camelStr);
+  const pascalObj = createNamedObject(pascalStr);
+  const snakeObj = createNamedObject(snakeStr);
+  const emptyObj = createNamedObject(emptyStr);
+  const invalids = [
+    undefined,
+    null,
+    "foo bar",
+    {},
+    { name: {} },
+    { name: { value: null } }
+  ];
+  describe("Basic name getter", () => {
+    it("Returns unmodified name for valid inputs", () => {
+      expect(getName(capitalObj)).to.equal(capitalStr);
+      expect(getName(camelObj)).to.equal(camelStr);
+      expect(getName(pascalObj)).to.equal(pascalStr);
+      expect(getName(snakeObj)).to.equal(snakeStr);
+      expect(getName(emptyObj)).to.equal(emptyStr);
+    });
+    it("Returns empty string for invalid inputs", () => {
+      invalids.forEach(item =>
+        expect(getName(item as NamedObject)).to.equal(emptyStr)
+      );
+    });
+  });
+  describe("camelCase name getter", () => {
+    it("Returns camelCase name for valid inputs", () => {
+      expect(getCamelCaseName(capitalObj)).to.equal(camelStr);
+      expect(getCamelCaseName(camelObj)).to.equal(camelStr);
+      expect(getCamelCaseName(pascalObj)).to.equal(camelStr);
+      expect(getCamelCaseName(snakeObj)).to.equal(camelStr);
+      expect(getCamelCaseName(emptyObj)).to.equal(emptyStr);
+    });
+    it("Returns empty string for invalid inputs", () => {
+      invalids.forEach(item =>
+        expect(getName(item as NamedObject)).to.equal(emptyStr)
+      );
+    });
+  });
+
+  describe("PascalCase name getter", () => {
+    it("Returns PascalCase name for valid inputs", () => {
+      expect(getPascalCaseName(capitalObj)).to.equal(pascalStr);
+      expect(getPascalCaseName(camelObj)).to.equal(pascalStr);
+      expect(getPascalCaseName(pascalObj)).to.equal(pascalStr);
+      expect(getPascalCaseName(snakeObj)).to.equal(pascalStr);
+      expect(getPascalCaseName(emptyObj)).to.equal(emptyStr);
+    });
+    it("Returns empty string for invalid inputs", () => {
+      invalids.forEach(item =>
+        expect(getName(item as NamedObject)).to.equal(emptyStr)
+      );
+    });
   });
 });


### PR DESCRIPTION
- Modified renderer to expose necessary information. Should also make adding generated examples easier in the future.
- Updated [APICLIENTS.md](https://github.com/SalesforceCommerceCloud/commerce-sdk/blob/wjh/update-usage-docs.W-7263996/packages/generator/APICLIENTS.md).
- Added test for `renderOperationList` to meet coverage threshold.