### PR TITLE
updateApis shouldn't fail if it's unable to fetch an asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "postinstall": "lerna bootstrap --hoist",
-    "updateApis": "lerna run updateApis",
+    "updateApis": "lerna run updateApis --stream",
     "build": "lerna run build",
     "test": "lerna run test",
     "test:debug": "lerna run test:debug",

--- a/packages/exchange-connector/package.json
+++ b/packages/exchange-connector/package.json
@@ -19,8 +19,7 @@
       "src/**/*.ts"
     ],
     "exclude": [
-      "src/exchangeDirectoryParser.ts",
-      "src/exchangeTools.ts"
+      "src/exchangeDirectoryParser.ts"
     ],
     "reporter": [
       "lcov",
@@ -31,9 +30,9 @@
     ],
     "all": true,
     "check-coverage": true,
-    "branches": 80,
-    "functions": 80,
-    "lines": 80,
+    "branches": 85,
+    "functions": 85,
+    "lines": 85,
     "statements": -10,
     "per-file": true
   },

--- a/packages/exchange-connector/test/exchangeTools.test.ts
+++ b/packages/exchange-connector/test/exchangeTools.test.ts
@@ -9,6 +9,7 @@ import _ from "lodash";
 
 import { expect, default as chai } from "chai";
 import chaiAsPromised from "chai-as-promised";
+import { removeRamlLinks } from "../src/exchangeTools";
 
 before(() => {
   chai.use(chaiAsPromised);
@@ -182,5 +183,45 @@ describe("Test groupByCategory method", () => {
       dog: [safeApisObject[3]],
       unclassified: [safeApisObject[1]]
     });
+  });
+});
+
+describe("removeRamlLinks", () => {
+  const REST_APIS: RestApi[] = [
+    {
+      id: "8888888/test-api/1.0.0",
+      name: "Test API",
+      groupId: "8888888",
+      assetId: "test-api",
+      fatRaml: {
+        classifier: "rest-api",
+        sha1: "sha1",
+        md5: "md5",
+        externalLink: "https://somewhere/fatraml.zip",
+        packaging: "zip",
+        createdDate: "today",
+        mainFile: "api.raml"
+      }
+    },
+    {
+      id: "8888888/test-api2/1.0.0",
+      name: "Test API",
+      groupId: "8888888",
+      assetId: "test-api",
+      fatRaml: {
+        classifier: "rest-api",
+        sha1: "sha1",
+        md5: "md5",
+        externalLink: "https://somewhere/fatraml2.zip",
+        packaging: "zip",
+        createdDate: "today",
+        mainFile: "api.raml"
+      }
+    }
+  ];
+
+  it("removes fat raml external links for all the apis", () => {
+    const apis = _.cloneDeep(REST_APIS);
+    expect(removeRamlLinks(apis)).to.not.contain("externalLink");
   });
 });

--- a/packages/generator/src/parser.ts
+++ b/packages/generator/src/parser.ts
@@ -15,6 +15,7 @@ import amf from "amf-client-js";
 import path from "path";
 import _ from "lodash";
 import { RestApi } from "@commerce-apps/exchange-connector";
+import { sdkLogger } from "../../core/src";
 
 export function processRamlFile(ramlFile: string): Promise<WebApiBaseUnit> {
   amf.plugins.document.WebApi.register();
@@ -97,6 +98,10 @@ export function processApiFamily(
   const promises = [];
   const ramlFileFromFamily = apiFamilyConfig[apiFamily];
   _.map(ramlFileFromFamily, (apiMeta: RestApi) => {
+    if(!apiMeta.fatRaml.createdDate) {
+      throw Error(`Some information about '${apiMeta.name}' is missing in 'apis/api-config.json'. 
+      Please ensure that '${apiMeta.name}' RAML and its dependencies are present in 'apis/', and all the required information is present in 'apis/api-config.json'.`);
+    }
     promises.push(
       processRamlFile(
         path.join(inputDir, apiMeta.assetId, apiMeta.fatRaml.mainFile)


### PR DESCRIPTION
- Display a message to manually download a RAML if exhcnage-downloader couldn't get it
- Increase the code coverage threshold to 85%
- Refactor exchange-downloader tests to use stubs for helper functions