### PR TITLE
Replace npm install with npm ci in circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: npm install
+            - run: npm ci
       - run: npm run build
       - run: npm run test
       - run: npm run test:integration
@@ -30,7 +30,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: npm install
+            - run: npm ci
       - run: npm run build
       - run: npm run test
       - run: npm run test:integration
@@ -46,7 +46,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: npm install
+            - run: npm ci
       - run: npm run build
       - run:
           name: Create npmrc file to authenticate with npm registry.


### PR DESCRIPTION
It should fix the issue where there is inconsistency in package.json and package-lock.json and the build still passes.

We should be able to close `W-7424350: Build should fail if git status is not clean`

Here's how npm ci is different from npm install:

* The project must have an existing package-lock.json or npm-shrinkwrap.json.
* If dependencies in the package lock do not match those in package.json, npm ci will exit with an error, instead of updating the package lock.
* npm ci can only install entire projects at a time: individual dependencies cannot be added with this command.
* If a node_modules is already present, it will be automatically removed before npm ci begins its install.
* It will never write to package.json or any of the package-locks: installs are essentially frozen.