### PR TITLE
Use custom config for publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,10 @@ jobs:
       - test
 
   publish:
-    executor: node-10
+    executor:
+      name: node/default
+      tag: '10.20.1'
+    working_directory: ~/publish
     steps:
       - build
       - run:
@@ -83,7 +86,7 @@ workflows:
       - build-node-14:
           filters:
             tags:
-              only: /^v.*/
+              ignore: /^v.*/
 
   build-test-deploy:
     jobs:


### PR DESCRIPTION
Dry run of npm publish with these settings worked as expected - https://app.circleci.com/pipelines/github/SalesforceCommerceCloud/commerce-sdk/1282/workflows/05fe13d5-f2d2-433b-8183-356f567bdf17/jobs/2115