### PR TITLE
Adding support for .nojekyll

### DIFF
--- a/packages/generator/.depcheckrc.yml
+++ b/packages/generator/.depcheckrc.yml
@@ -11,5 +11,6 @@ ignores:
     'tslib',
     'typescript',
     'typedoc-plugin-external-module-map',
+    'typedoc-plugin-nojekyll',
     'utility-types',
   ]

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -185,6 +185,7 @@
     "snyk": "^1.320.5",
     "tmp": "^0.2.0",
     "tslib": "^1.10.0",
+    "typedoc-plugin-nojekyll": "^1.0.1",
     "utility-types": "^3.10.0"
   },
   "dependencies": {


### PR DESCRIPTION
Github pages uses jekyll, which ignores all files that start with _ . 
Typedoc is creating a couple of files (index and helpers) with leading (and trailing) underscores.
This adds a directive to typedoc to create a file named .nojekyll which tells github pages to not use jekyll.