### PR TITLE
Log fetch after assigning headers

### DIFF
--- a/packages/core/src/base/staticClient.ts
+++ b/packages/core/src/base/staticClient.ts
@@ -157,12 +157,12 @@ async function runFetch(
   // This line merges the values and then strips anything that is undefined.
   //  (NOTE: Not sure we have to, as all tests pass regardless, but going to anyways)
   finalOptions = _.pickBy(finalOptions, _.identity);
-
-  logFetch(resource, finalOptions);
-  // Convert Headers object into a regular object. `http-cache-semantics`, a 
+  // Convert Headers object into a regular object. `http-cache-semantics`, a
   // package used by `make-fetch-happen` to manipulate headers expects headers
   // to be regular objects.
   finalOptions.headers = _.fromPairs([...headers]);
+
+  logFetch(resource, finalOptions);
   const response = await fetch(resource, finalOptions);
   logResponse(response);
 


### PR DESCRIPTION
Changes
- Log fetch after assigning headers object

Acceptance Criteria
- Ensure in DEBUG log level, curl command includes headers