### PR TITLE
Fix cache manager types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1568,6 +1568,15 @@
 				"handlebars": ">=4.1.0"
 			}
 		},
+		"@types/ioredis": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.17.0.tgz",
+			"integrity": "sha512-2wmT+lB9JAHSYlBrmJGeYDQ4cGlIgxmaC3Bv85LJws/G/OkoFoxPezhMqtTp0JMCgsMadIoI9c43QvRz8WKLSw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/json-schema": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/fs-extra": "^8.0.0",
     "@types/handlebars-helpers": "^0.5.2",
+    "@types/ioredis": "^4.17.0",
     "@types/lodash": "^4.14.146",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.6.9",

--- a/packages/core/src/base/cacheManagerKeyv.ts
+++ b/packages/core/src/base/cacheManagerKeyv.ts
@@ -123,14 +123,14 @@ const matchDetails = (req: fetch.Request, cached: fetch.Request): boolean => {
  * docs: https://developer.mozilla.org/en-US/docs/Web/API/Cache
  * https://www.npmjs.com/package/keyv
  */
-export class CacheManagerKeyv implements ICacheManager {
+export class CacheManagerKeyv<T> implements ICacheManager {
   public keyv;
   public uncacheableRequestHeaders: string[] = ["authorization"];
 
   constructor(options?: {
     connection?: string;
-    keyvOptions?: {};
-    keyvStore?: {};
+    keyvOptions?: Keyv.Options<T>;
+    keyvStore?: Keyv.Store<T>;
   }) {
     if (options?.keyvStore) {
       this.keyv = new Keyv({ store: options.keyvStore });

--- a/packages/core/src/base/cacheManagerRedis.ts
+++ b/packages/core/src/base/cacheManagerRedis.ts
@@ -8,6 +8,7 @@
 
 import Redis from "ioredis";
 import KeyvRedis from "@keyv/redis";
+import Keyv from "keyv";
 
 import { CacheManagerKeyv } from "./cacheManagerKeyv";
 
@@ -17,12 +18,12 @@ import { CacheManagerKeyv } from "./cacheManagerKeyv";
  * docs: https://developer.mozilla.org/en-US/docs/Web/API/Cache
  * https://www.npmjs.com/package/keyv
  */
-export class CacheManagerRedis extends CacheManagerKeyv {
+export class CacheManagerRedis<T> extends CacheManagerKeyv<T> {
   constructor(options?: {
     connection?: string;
-    keyvOptions?: {};
-    keyvStore?: {};
-    clusterConfig?: {};
+    keyvOptions?: Keyv.Options<T>;
+    keyvStore?: Keyv.Store<T>;
+    clusterConfig?: Redis.ClusterNode[];
   }) {
     if (options?.clusterConfig) {
       // TODO: Remove workaround when cluster support is added (hopefully soon):


### PR DESCRIPTION
Keyv expects specific types. This change updates the type definitions for the cache manager to use those types.