### PR TITLE
Add shopper login object ID

### DIFF
--- a/docs/classes/customer.shopperlogin.html
+++ b/docs/classes/customer.shopperlogin.html
@@ -73,7 +73,7 @@
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
 						<a href="#shopper-login" id="shopper-login" style="color: inherit; text-decoration: none;">
-							<h1><a href="https://developer.commercecloud.com/s/api-details/">Shopper Login</a></h1>
+							<h1><a href="https://developer.commercecloud.com/s/api-details/a003k00000VWfNDAA1">Shopper Login</a></h1>
 						</a>
 					</div>
 					<p><em>Enable shoppers to login via federation to any external IDP, get access token and use it to access shopper APIs</em><br /></p>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,6 +12,9 @@ export const PRIMITIVE_DATA_TYPE_MAP = {
   "http://www.w3.org/2001/XMLSchema#float": "number",
   "http://www.w3.org/2001/XMLSchema#boolean": "boolean",
 };
+/**
+ * Map of API asset ID to CCDC object ID, used to generate documentation URLs
+ */
 export const ASSET_OBJECT_MAP = {
   assignments: "a003k00000UHvoaAAD",
   campaigns: "a003k00000UHvobAAD",
@@ -33,4 +36,5 @@ export const ASSET_OBJECT_MAP = {
   "shopper-search": "a003k00000UHwuFAAT",
   "shopper-stores": "a003k00000UHwuPAAT",
   "source-code-groups": "a003k00000UHvpTAAT",
+  "shopper-login": "a003k00000VWfNDAA1",
 };

--- a/src/lib/templateHelpers.ts
+++ b/src/lib/templateHelpers.ts
@@ -73,7 +73,14 @@ export function addNamespace(content: string, namespace: any): string {
  * @returns The custom object id as a string
  */
 export const getObjectIdByAssetId = (assetId: string): string => {
-  return ASSET_OBJECT_MAP[assetId];
+  if (ASSET_OBJECT_MAP.hasOwnProperty(assetId)) {
+    return ASSET_OBJECT_MAP[assetId];
+  }
+  // When this error occurs, find the corresponding API in the CCDC and copy the
+  // object ID from the URL. Add the asset ID and object ID to ASSET_OBJECT_MAP
+  // in ./config.ts.
+  // CCDC API Reference: https://developer.commercecloud.com/s/api-reference
+  throw new Error(`Missing CCDC object ID for "${assetId}`);
 };
 
 /**

--- a/src/lib/templateHelpers.ts
+++ b/src/lib/templateHelpers.ts
@@ -80,7 +80,7 @@ export const getObjectIdByAssetId = (assetId: string): string => {
   // object ID from the URL. Add the asset ID and object ID to ASSET_OBJECT_MAP
   // in ./config.ts.
   // CCDC API Reference: https://developer.commercecloud.com/s/api-reference
-  throw new Error(`Missing CCDC object ID for "${assetId}`);
+  throw new Error(`Missing CCDC object ID for "${assetId}"`);
 };
 
 /**


### PR DESCRIPTION
It's missing, which means that links in our documentation are broken.

Also changed the helper function to throw if an object ID is missing, so that we don't end up with broken links in the future.