### PR TITLE
Remove browser globals and fix types

### DIFF
--- a/apis/.metadata.json
+++ b/apis/.metadata.json
@@ -1,1 +1,1 @@
-{"shopperAuthClient":"Customer.ShopperCustomers","shopperAuthApi":"authorizeCustomer"}
+{"shopperAuthClient":"Customer.ShopperCustomers","shopperAuthApi":"authorizeCustomer","shopperAuthDataType":"Customer"}

--- a/base.tsconfig.json
+++ b/base.tsconfig.json
@@ -6,6 +6,7 @@
         "declaration": true,
         "sourceMap": true,
         "target": "ES6",
+        "lib": ["ES6"],
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames":true,
         "importHelpers": true,

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -5,11 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import path from "path";
 import { generate } from "@commerce-apps/raml-toolkit";
 import { registerHelpers, registerPartials, setupApis } from "./lib/utils";
 
-const API_DIRECTORY =
-  process.env.COMMERCE_SDK_INPUT_DIR || `${__dirname}/../apis`;
+const API_DIRECTORY = path.resolve(
+  process.env.COMMERCE_SDK_INPUT_DIR || `${__dirname}/../apis`
+);
 
 registerHelpers();
 registerPartials();
@@ -18,5 +20,5 @@ console.log(`Creating SDK for ${API_DIRECTORY}`);
 
 setupApis(
   API_DIRECTORY,
-  `${__dirname}/../renderedTemplates`
+  path.resolve(`${__dirname}/../renderedTemplates`)
 ).then((apis: generate.ApiMetadata) => apis.render());

--- a/src/lib/templateHelpers.ts
+++ b/src/lib/templateHelpers.ts
@@ -18,7 +18,7 @@ import { commonParameterPositions } from "@commerce-apps/core";
  * @param namespace - to be prefixed to types
  * @returns the content prefixed with the namespace
  */
-export function addNamespace(content: string, namespace: any): string {
+export function addNamespace(content: string, namespace: string): string {
   // Not handling invalid content.
   if (!content) {
     throw new Error("Invalid content");

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,7 +31,6 @@ export function registerHelpers(): void {
  * Register any customer partials we have in our pipeline
  */
 export function registerPartials(): void {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   generate.registerPartial(
     "dtoPartial",
     path.join(TEMPLATE_DIRECTORY, "dtoPartial.ts.hbs")
@@ -42,7 +41,6 @@ export function registerPartials(): void {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function addTemplates(
   apis: generate.ApiMetadata,
   outputBasePath: string

--- a/src/updateApis.ts
+++ b/src/updateApis.ts
@@ -24,6 +24,7 @@ const STAGING_API_PATH = `${__dirname}/../testIntegration/stagingApis`;
 const CUSTOM_METADATA = {
   shopperAuthClient: "Customer.ShopperCustomers",
   shopperAuthApi: "authorizeCustomer",
+  shopperAuthDataType: "Customer",
 };
 
 // DOWNLOAD PRODUCTION DATA

--- a/templates/helpers.ts.hbs
+++ b/templates/helpers.ts.hbs
@@ -1,14 +1,10 @@
 import { ShopperToken, stripBearer, ResponseError, getObjectFromResponse } from "@commerce-apps/core"
 import  * as sdk from "./"
 
-//type of the input parameter of auth function
-type AuthFuncParamType = Parameters<typeof sdk.{{metadata.shopperAuthClient}}.prototype.{{metadata.shopperAuthApi}}>[0];
-// get the type(s) wrapped inside the promise
-type Unpacked<T> = T extends Promise<infer U> ? U : T;
-// get the return type of shopperAuthApi 
-type CustomerReturnType = ReturnType<typeof sdk.{{metadata.shopperAuthClient}}.prototype.{{metadata.shopperAuthApi}}>;
-// get only the dto type by excluding the response type
-type CustomerType = Exclude<Unpacked<CustomerReturnType>, Response>
+// Type of the first input parameter for the auth function
+type AuthFuncParamType = Parameters<sdk.{{metadata.shopperAuthClient}}["{{metadata.shopperAuthApi}}"]>[0];
+// Type returned by the auth function
+type CustomerType = sdk.{{metadata.shopperAuthClient}}.{{metadata.shopperAuthDataType}};
 
 /**
  * This wraps the parameters for the authorization call to retrieve a token.
@@ -34,7 +30,7 @@ export async function getShopperToken (
 ): Promise<ShopperToken<CustomerType>>{
     let client = new sdk.{{metadata.shopperAuthClient}}(clientConfig);
 
-    const response: Response = (await client.{{metadata.shopperAuthApi}}({body}, true));
+    const response = await client.{{metadata.shopperAuthApi}}({body}, true);
     if (!response.ok) {
         throw new ResponseError(response);
     }

--- a/testIntegration/stagingApis/.metadata.json
+++ b/testIntegration/stagingApis/.metadata.json
@@ -1,1 +1,1 @@
-{"shopperAuthClient":"Customer.ShopperCustomers","shopperAuthApi":"authorizeCustomer"}
+{"shopperAuthClient":"Customer.ShopperCustomers","shopperAuthApi":"authorizeCustomer","shopperAuthDataType":"Customer"}


### PR DESCRIPTION
This PR removes browser global from being used by the TypeScript compiler, and fixes broken code that incorrectly used those globals.

The `Response` used in [helpers.ts](https://github.com/SalesforceCommerceCloud/commerce-sdk/blob/86763b1255808a56e59f0a7d782943683223cab9/templates/helpers.ts.hbs#L11) is _supposed_ to refer to the `Response` exported by `minipass-fetch` (via `@commerce-apps/core`). It does not, because the class was not imported. This did not result in an error because TypeScript defaults to including types for browser globals. Changing the file to use the correct `Response` caused [`CustomerType`](https://github.com/SalesforceCommerceCloud/commerce-sdk/blob/86763b1255808a56e59f0a7d782943683223cab9/templates/helpers.ts.hbs#L11) to break. This is because there are no type definitions for `minipass-fetch`, so the type defaults to `any`, and `Exclude<..., any>` is `never`. As a result, the easiest way to access the desired type is to simply add an additional metadata property.

The additional metadata can be removed if (1) types for `minipass-fetch` are ever added (via `@types/minipass-fetch` or directly added to the package) or (2) a solution is found for the problem described in [this sample](https://www.typescriptlang.org/play?ts=3.9.7#code/C4TwDgpgBAIhBmBDArgG2AFXNAvFARACYIrr4DcAUKJFAPIBuEATswJbFa174D2TrDhAqUAxqkQBnSVAwRJwKAG9KUNVAC2EYAAtehABQBKAFxQACs14a2kiAB44SNJmwA+Kuq9RV6rbv17DCgIAA9gCAA7QhkAI15eVAhESLcDX28ofhZ2YjMMDKhTCysbOyCQ8KiYqGBmZGgAfnoBXIguaDMnUldID0pC-z1DQq9swWJGs3jE5MiAGkLiy2tbB26XDqgAHxacoQ63ZVH1Zm1kZkiS1bsAOjPJRKYDcbaoZr5WoXwoMyISFz4IyedQAX0o4Oo2CgAFVImBEKIANYQQhBI54YJhCLRGQrMoONiReAsWFHZow36yKhQ2gASUiEWYWkIbEQESgeDhCORqPsACVzpcOkF5MAANr4Ib6fAAXTc-UoAHolVAAMrWCB6ADulTqiMUn32xB+8FKsjFkulhDlUG1bACyEUZxJZ0ioiJAHMCK9vllmARiM4yLToHB2ExCIxjbgCI14yIVbIdLY7bw0IQoLFoIgoI9UE62LwFlmnVAHVBkHYZBt0B15naU6IdOWZJFeIoDchEKhUCAoIgGIg2BJYklQ1AAEKIQgagvAItXPAAUVC4mQxHs3MRKLRguAF0iIrkCit2mGcoVDdrvQgiuVqowKZk8GQ7oXxbzbA0YD7UGIGjFgozDsvItQ6NAxCSGwZyZtmOiDkWzCUFIIDulAr7vouUACGw8AgJOWqIbwAbGMcXiiEBigRAonJQJEEC6iewDGDSXhJIo7aIMw3p4Ig2rDtRYq3NarGFFxPF0f8wbABQUBJnQADS4m8NxvE+l8JrkPJqrLqwJEDOx2gYT2kj9nxAkVjRwAiee+gGEgqB2MChSOWZUlBj0ckKcpXhueZGkxt5un6chhQcbU9S6AF-GCbUwmiXUDQuV4SXRR5AJkNpSZ6VYyGpVFOgBUaEzCNlqpKYZpxClc4oSZ6Db+Q2aVFbK5VQAAUlW1G8AODC8Bw9G9W+Vaojh3EyDkBmgkAA).