### PR TITLE
Set Content-Type header for requests with bodies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -232,28 +232,49 @@
       }
     },
     "@commerce-apps/core": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@commerce-apps/core/-/core-1.5.4.tgz",
-      "integrity": "sha512-JOhvlBqMq54LxfGdEsBK59gQEcDNwtaeKngBJ9a1j5uOi/+th3HNPqGqpt5sVeatQIkClDQuVZa0J9uHFQlf4A==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@commerce-apps/core/-/core-1.5.5.tgz",
+      "integrity": "sha512-AlNLY2Mv0/2sNbJq74MHrYKiCXyJytekgfrxUcaYARnB8KGvexV4MhHiVYj1TYVINroLrO4rW0D9uKLCn7nHxA==",
       "requires": {
-        "@keyv/redis": "^2.1.2",
-        "dotenv": "^8.2.0",
+        "@keyv/redis": "^2.2.0",
+        "dotenv": "^8.6.0",
         "fetch-to-curl": "^0.5.2",
-        "ioredis": "^4.17.3",
+        "ioredis": "^4.28.1",
         "jsonwebtoken": "^8.5.1",
-        "keyv": "^4.0.3",
+        "keyv": "^4.0.4",
         "lodash": "^4.17.21",
-        "loglevel": "^1.7.1",
+        "loglevel": "^1.8.0",
         "make-fetch-happen": "^8.0.14",
-        "minipass-fetch": "^1.3.4",
-        "qs": "^6.10.1",
+        "minipass-fetch": "^1.4.1",
+        "qs": "^6.10.2",
         "quick-lru": "^5.1.1",
-        "retry": "^0.12.0",
-        "snyk": "^1.685.0",
+        "retry": "^0.13.1",
+        "snyk": "^1.759.0",
         "ssri": "^8.0.1",
         "tslib": "^1.14.1"
       },
       "dependencies": {
+        "minipass-fetch": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+          "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+          "requires": {
+            "encoding": "^0.1.12",
+            "minipass": "^3.1.0",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.0.0"
+          }
+        },
+        "retry": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+          "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+        },
+        "snyk": {
+          "version": "1.826.0",
+          "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.826.0.tgz",
+          "integrity": "sha512-ZqkDPgO37D7sgxY+Y8J+4UK9mq89By9lcp/KUP9PfqETxWclVZXlcaLIkaY4BkDCktPDNtS6WHgYR3ApL+9mMQ=="
+        },
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -2156,29 +2177,11 @@
       "dev": true
     },
     "@keyv/redis": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@keyv/redis/-/redis-2.1.2.tgz",
-      "integrity": "sha512-D6vNOuyH/5cBNfHcyxzck1l7V+Qd4RAT7uz2SHYAjutbXQ03o3SSneRyvrp76H4/uvHyutPWTJ1Za3EpGSVe5g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@keyv/redis/-/redis-2.2.2.tgz",
+      "integrity": "sha512-/Md3orSEJr/6oAHt+OlQydEJLf/bWI82YaHCje6BqZGHJJsCZ6LfrNIB0GrC3qWE8NB7vaG94y7L4mOXL8ztbg==",
       "requires": {
-        "ioredis": "~4.17.1"
-      },
-      "dependencies": {
-        "ioredis": {
-          "version": "4.17.3",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.17.3.tgz",
-          "integrity": "sha512-iRvq4BOYzNFkDnSyhx7cmJNOi1x/HWYe+A4VXHBu4qpwJaGT1Mp+D2bVGJntH9K/Z/GeOM/Nprb8gB3bmitz1Q==",
-          "requires": {
-            "cluster-key-slot": "^1.1.0",
-            "debug": "^4.1.1",
-            "denque": "^1.1.0",
-            "lodash.defaults": "^4.2.0",
-            "lodash.flatten": "^4.4.0",
-            "redis-commands": "1.5.0",
-            "redis-errors": "^1.2.0",
-            "redis-parser": "^3.0.0",
-            "standard-as-callback": "^2.0.1"
-          }
-        }
+        "ioredis": "^4.28.2"
       }
     },
     "@microsoft/tsdoc": {
@@ -5069,9 +5072,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true
     },
     "for-in": {
@@ -5916,9 +5919,9 @@
       "dev": true
     },
     "ioredis": {
-      "version": "4.27.9",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.9.tgz",
-      "integrity": "sha512-hAwrx9F+OQ0uIvaJefuS3UTqW+ByOLyLIV+j0EH8ClNVxvFyH9Vmb08hCL4yje6mDYT5zMquShhypkd50RRzkg==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.3.tgz",
+      "integrity": "sha512-9JOWVgBnuSxpIgfpjc1OeY1OLmA4t2KOWWURTDRXky+eWO0LZhI33pQNT9gYxANUXfh5p/zYephYni6GPRsksQ==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.1",
@@ -5937,11 +5940,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
-        },
-        "redis-commands": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-          "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
         }
       }
     },
@@ -6499,9 +6497,9 @@
       }
     },
     "keyv": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.5.tgz",
+      "integrity": "sha512-531pkGLqV3BMg0eDqqJFI0R1mkK1Nm5xIP2mM6keP5P8WfFtCkg2IOwplTUmlGoTgIg9yQYZ/kdihhz89XH3vA==",
       "requires": {
         "json-buffer": "3.0.1"
       }
@@ -6796,9 +6794,9 @@
       }
     },
     "loglevel": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
-      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -7403,9 +7401,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -7685,9 +7683,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -7958,9 +7956,9 @@
       }
     },
     "redis-commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
-      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
     },
     "redis-errors": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "@commerce-apps/core": "^1.5.4",
+    "@commerce-apps/core": "^1.5.5",
     "lodash": "^4.17.21",
     "retry": "^0.12.0",
     "snyk": "^1.736.0",

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -145,7 +145,12 @@
         {{/if}}
       {{/each}}
 
-      const headers = mergeHeaders(getHeaders(options), { [USER_AGENT_HEADER]: USER_AGENT_VALUE });
+      const headers = mergeHeaders(getHeaders(options), {
+        {{#if (isRequestWithPayload request)}}
+        "Content-Type": "{{{getMediaTypeFromRequest request}}}",
+        {{/if}}
+        [USER_AGENT_HEADER]: USER_AGENT_VALUE
+      });
 
       // @ts-ignore
       return StaticClient.{{method}}({

--- a/testIntegration/tests/requests.test.ts
+++ b/testIntegration/tests/requests.test.ts
@@ -24,12 +24,18 @@ describe("Requests with body", () => {
 
   it("sends correct media type for urlencoded endpoints", async () => {
     const body = {
-      token:
-        "ry5XU_WHX20S6Cn6W7keFIs7Pzkv4wTZJS9Yvh0Ve9A.cdBxoCY9Q3jffQQOFnb_qghbSmSRnn9-2H4GwFTDMTk",
+      token: "TOKEN",
       // eslint-disable-next-line @typescript-eslint/camelcase
       token_type_hint: "REFRESH_TOKEN",
     };
     nock("https://short_code.api.commercecloud.salesforce.com")
+      .filteringRequestBody((body) => {
+        // Putting the assertion here isn't ideal, but it's the only place I can find that nock
+        // exposes the raw contents of the request body. (The body provided to `.post` has already
+        // been parsed to an object, so we can't use that to detect the type.)
+        expect(body).to.equal("token=TOKEN&token_type_hint=REFRESH_TOKEN");
+        return body;
+      })
       .post(
         "/shopper/auth/v1/organizations/ORGANIZATION_ID/oauth2/revoke",
         body
@@ -45,6 +51,13 @@ describe("Requests with body", () => {
   it("sends correct media type for JSON endpoints", async () => {
     const body = { query: "pants" };
     nock("https://short_code.api.commercecloud.salesforce.com")
+      .filteringRequestBody((body) => {
+        // Putting the assertion here isn't ideal, but it's the only place I can find that nock
+        // exposes the raw contents of the request body. (The body provided to `.post` has already
+        // been parsed to an object, so we can't use that to detect the type.)
+        expect(body).to.equal('{"query":"pants"}');
+        return body;
+      })
       .post(
         "/product/products/v1/organizations/ORGANIZATION_ID/product-search",
         body

--- a/testIntegration/tests/requests.test.ts
+++ b/testIntegration/tests/requests.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from "chai";
+import { ClientConfig } from "commerce-sdk";
+import { ShopperLogin } from "commerce-sdk/dist/customer/customer";
+import { Products } from "commerce-sdk/dist/product/product";
+import nock from "nock";
+
+const config: ClientConfig = {
+  parameters: {
+    shortCode: "SHORT_CODE",
+    organizationId: "ORGANIZATION_ID",
+    siteId: "SITE_ID",
+    clientId: "CLIENT_ID",
+  },
+};
+
+describe("Requests with body", () => {
+  beforeEach(nock.cleanAll);
+
+  it("sends correct media type for urlencoded endpoints", async () => {
+    const body = {
+      token:
+        "ry5XU_WHX20S6Cn6W7keFIs7Pzkv4wTZJS9Yvh0Ve9A.cdBxoCY9Q3jffQQOFnb_qghbSmSRnn9-2H4GwFTDMTk",
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      token_type_hint: "REFRESH_TOKEN",
+    };
+    nock("https://short_code.api.commercecloud.salesforce.com")
+      .post(
+        "/shopper/auth/v1/organizations/ORGANIZATION_ID/oauth2/revoke",
+        body
+      )
+      .matchHeader("Content-Type", "application/x-www-form-urlencoded")
+      .reply(200);
+
+    const client = new ShopperLogin(config);
+    await client.revokeToken({ body });
+    expect(nock.isDone()).to.be.true;
+  });
+
+  it("sends correct media type for JSON endpoints", async () => {
+    const body = { query: "pants" };
+    nock("https://short_code.api.commercecloud.salesforce.com")
+      .post(
+        "/product/products/v1/organizations/ORGANIZATION_ID/product-search",
+        body
+      )
+      .query({ siteId: "SITE_ID" })
+      .matchHeader("Content-Type", "application/json")
+      .reply(200);
+
+    const client = new Products(config);
+    await client.searchProducts({ body });
+    expect(nock.isDone()).to.be.true;
+  });
+});


### PR DESCRIPTION
Combined with https://github.com/SalesforceCommerceCloud/commerce-sdk-core/pull/86, will add support for endpoints that use `application/x-www-form-urlencoded`, i.e. SLAS.

(Build will fail until the upstream PR is merged and released.)