### PR TITLE
W-11235782: Add .npmrc file to pull from npm registry instead of nexus

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org


### PR DESCRIPTION
This PR is to ensure future node packages that are added pull from the npm registry instead of nexus due to CI pipeline issues where the CI is unable to connect to nexus