### PR TITLE
chore: Add git2gus integration

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,0 +1,14 @@
+{
+  "productTag": "a1aB0000000MacsIAC",
+  "issueTypeLabels": {
+    "type:feature": "",
+    "type:bug": "BUG P3",
+    "type:security": "BUG P2",
+    "type:dependency": "USER STORY",
+    "type:duplicate": "",
+    "type:community-contrib": "USER STORY"
+  },
+  "defaultBuild": "backlog",
+  "hideWorkItemUrl": "true",
+  "statusWhenClosed": "CLOSED"
+}


### PR DESCRIPTION
Adding Git2Gus integration
Adding the following labels will create objects in Gus in the Commerce SDK product tag
type:dependency = Work Item
type:security = P2 Bug
type:bug = P3 Bug
type:community-contrib = Work Item