### PR TITLE
fix: use nanoid as regular dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@commerce-apps/core": "^1.6.0",
         "lodash": "^4.17.21",
+        "nanoid": "^3.3.3",
         "retry": "^0.12.0",
         "tslib": "^2.4.0"
       },
@@ -38,7 +39,6 @@
         "fs-extra": "^9.1.0",
         "handlebars-helpers": "^0.10.0",
         "mocha": "^8.4.0",
-        "nanoid": "^3.3.3",
         "nock": "^13.2.2",
         "nyc": "^15.1.0",
         "prettier": "^2.5.1",
@@ -9334,7 +9334,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
       "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -19781,8 +19780,7 @@
     "nanoid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-      "dev": true
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@commerce-apps/core": "^1.6.0",
     "lodash": "^4.17.21",
+    "nanoid": "^3.3.3",
     "retry": "^0.12.0",
     "tslib": "^2.4.0"
   },
@@ -71,7 +72,6 @@
     "fs-extra": "^9.1.0",
     "handlebars-helpers": "^0.10.0",
     "mocha": "^8.4.0",
-    "nanoid": "^3.3.3",
     "nock": "^13.2.2",
     "nyc": "^15.1.0",
     "prettier": "^2.5.1",

--- a/testIntegration/tests/slasHelper.test.ts
+++ b/testIntegration/tests/slasHelper.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+/* eslint-disable @typescript-eslint/camelcase  */
+
+import { expect } from "chai";
+import { slasHelpers, Customer } from "commerce-sdk";
+import nock from "nock";
+
+const createSlasClient = (clientConfig) => {
+  return new Customer.ShopperLogin(clientConfig);
+};
+
+describe("slasHelpers", () => {
+  afterEach(nock.cleanAll);
+
+  const clientConfig = {
+    parameters: {
+      shortCode: "short_code",
+      organizationId: "organization_id",
+      clientId: "client_id",
+      siteId: "site_id",
+    },
+  };
+
+  const expectedTokenResponse: Customer.ShopperLogin.TokenResponse = {
+    access_token: "access_token",
+    id_token: "id_token",
+    refresh_token: "refresh_token",
+    expires_in: 0,
+    token_type: "token_type",
+    usid: "usid",
+    customer_id: "customer_id",
+    enc_user_id: "enc_user_id",
+  };
+
+  it("can retrieve an access token from guest login flow", async () => {
+    const { shortCode, organizationId } = clientConfig.parameters;
+
+    nock(`https://${shortCode}.api.commercecloud.salesforce.com`)
+      .get(`/shopper/auth/v1/organizations/${organizationId}/oauth2/authorize`)
+      .query(true)
+      .reply(303, { response_body: "response_body" });
+
+    nock(`https://${shortCode}.api.commercecloud.salesforce.com`)
+      .post(`/shopper/auth/v1/organizations/${organizationId}/oauth2/token`)
+      .query(true)
+      .reply(200, expectedTokenResponse);
+
+    const slasClient = createSlasClient(clientConfig);
+    const tokenResponse = await slasHelpers.loginGuestUser(slasClient, {
+      redirectURI: "redirect_uri",
+    });
+    const accessToken = tokenResponse.access_token;
+
+    expect(nock.isDone()).to.be.true;
+    expect(accessToken).to.be.equal(expectedTokenResponse.access_token);
+    expect(tokenResponse).to.be.deep.equals(expectedTokenResponse);
+  });
+});


### PR DESCRIPTION
This PR resolves issue https://github.com/SalesforceCommerceCloud/commerce-sdk/issues/368. This PR also contains an integration test that uses `nanoid` underneath the hood. The integration tests package the `commerce-sdk` to be used as node module, so the test pulls the slasHelpers from the `commerce-sdk` package and tests a basic guest login flow that uses `nanoid` through the slasHelpers.


To run the tests within the repository:

```bash
git checkout ju/fix_nanoid
cd testIntegration
npm run test:ci
```