### PR TITLE
Update SLAS helper to require channel_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 ## CHANGELOG
 
-### :warning: Planned future release will contain breaking changes :warning
-
-Due to an issue with the generation of the type definitions, an upcoming release
-of the SDK will change type definitions to include namespaces. As this is a
-breaking change, a new major version will be released (v5.0.0). Only the names of
-the types will change, not their contents or any of the exported code. If you
-only use JavaScript, or if you use TypeScript but only import the client classes,
-then your usage **will not change**. You will likely only need to make changes if
-you import the type definitions directly.
-
 ## v4.0.0
 
 ### :warning: Planned Shopper Context Changes :warning: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ you import the type definitions directly.
 
 ## v4.0.0
 
+### :warning: Planned Shopper Context Changes :warning: 
+
+Starting July 31st 2024, all endpoints in the Shopper context API will require the `siteId` parameter for new customers. This field is marked as optional for backward compatibility and will be changed to mandatory tentatively by January 2025.
+
 ### Enchancements
 
-- Update SLAS helper function `loginGuestUserPrivate` to require `channel_id` [#406](https://github.com/SalesforceCommerceCloud/commerce-sdk/pull/406)
+- Update SLAS helper function `loginGuestUserPrivate` to require `channel_id` as SLAS requires `channel_id` when requesting a guest access token with a `grant_type` of `client_credentials` starting July 31st 2024 [#406](https://github.com/SalesforceCommerceCloud/commerce-sdk/pull/406)
+  - See the [announcement on the developer docs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas.html#guest-tokens) for more information
 
 ## v3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@
 
 Due to an issue with the generation of the type definitions, an upcoming release
 of the SDK will change type definitions to include namespaces. As this is a
-breaking change, a new major version will be released (v4.0.0). Only the names of
+breaking change, a new major version will be released (v5.0.0). Only the names of
 the types will change, not their contents or any of the exported code. If you
 only use JavaScript, or if you use TypeScript but only import the client classes,
 then your usage **will not change**. You will likely only need to make changes if
 you import the type definitions directly.
+
+## v4.0.0
+
+### Enchancements
+
+- Update SLAS helper function `loginGuestUserPrivate` to require `channel_id` [#406](https://github.com/SalesforceCommerceCloud/commerce-sdk/pull/406)
 
 ## v3.1.0
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@ The Salesforce Commerce SDK allows easy interaction with the Salesforce B2C Comm
 
 Visit the [Commerce Cloud Developer Center](https://developer.salesforce.com/developer-centers/commerce-cloud) to learn more about Salesforce Commerce. The developer center has API documentation, getting started guides, community forums, and more.
 ​
+## :warning: Planned Shopper Context Changes :warning:
+
+Starting July 31st 2024, all endpoints in the Shopper context API will require the `siteId` parameter for new customers. This field is marked as optional for backward compatibility and will be changed to mandatory tentatively by January 2025.
+
 ## :warning: Planned future release will contain breaking changes :warning:
 Due to an issue with the generation of the type definitions, an upcoming release
 of the SDK will change type definitions to include namespaces. As this is a
-breaking change, a new major version will be released (v4.0.0). Only the names of
+breaking change, a new major version will be released (v5.0.0). Only the names of
 the types will change, not their contents or any of the exported code. If you
 only use JavaScript, or if you use TypeScript but only import the client classes,
 then your usage **will not change**. You will likely only need to make changes if

--- a/README.md
+++ b/README.md
@@ -8,15 +8,6 @@ Visit the [Commerce Cloud Developer Center](https://developer.salesforce.com/dev
 
 Starting July 31st 2024, all endpoints in the Shopper context API will require the `siteId` parameter for new customers. This field is marked as optional for backward compatibility and will be changed to mandatory tentatively by January 2025.
 
-## :warning: Planned future release will contain breaking changes :warning:
-Due to an issue with the generation of the type definitions, an upcoming release
-of the SDK will change type definitions to include namespaces. As this is a
-breaking change, a new major version will be released (v5.0.0). Only the names of
-the types will change, not their contents or any of the exported code. If you
-only use JavaScript, or if you use TypeScript but only import the client classes,
-then your usage **will not change**. You will likely only need to make changes if
-you import the type definitions directly.
-
 ## Prerequisites
 
 Download and install Node.js and npm [here](https://nodejs.org/en/download/).

--- a/src/static/helpers/slas.test.ts
+++ b/src/static/helpers/slas.test.ts
@@ -245,6 +245,30 @@ describe("Guest user flow", () => {
     expect(accessToken).to.be.deep.equals(expectedTokenResponse);
   });
 
+  it("throws an error when channel_id is not passed into private client", async () => {
+    const mockSlasClient = createSlasClient();
+    const mockSlasClientNoSiteID = {
+      ...mockSlasClient,
+      clientConfig: {
+        parameters: {
+          ...mockSlasClient.clientConfig.parameters,
+          siteId: undefined, // siteId in client config is used for channel_id
+        },
+      },
+    };
+
+    try {
+      await slasHelper.loginGuestUserPrivate(mockSlasClientNoSiteID, {
+        clientSecret: credentials.clientSecret,
+      });
+      expect.fail("Expected error not thrown, this line should not be reached");
+    } catch (error) {
+      expect(error.message).to.equal(
+        "Required argument channel_id is not provided through clientConfig.parameters.siteId"
+      );
+    }
+  });
+
   it("using a public client uses a code verifier and code challenge to generate token", async () => {
     const mockSlasClient = createSlasClient();
     const spy = sinon.spy(mockSlasClient, "getAccessToken");

--- a/src/static/helpers/slas.test.ts
+++ b/src/static/helpers/slas.test.ts
@@ -211,6 +211,7 @@ describe("Guest user flow", () => {
     },
     body: {
       grant_type: "client_credentials",
+      channel_id: "site_id",
     },
   };
 

--- a/src/static/helpers/slas.ts
+++ b/src/static/helpers/slas.ts
@@ -138,7 +138,7 @@ export async function loginGuestUserPrivate(
     clientSecret: string;
   },
   usid?: string
-): Promise<TokenResponse> {  
+): Promise<TokenResponse> {
   if (!slasClient.clientConfig.parameters.siteId) {
     throw new Error(
       "Required argument channel_id is not provided through clientConfig.parameters.siteId"
@@ -189,6 +189,7 @@ export async function loginGuestUser(
 
   const tokenBody: TokenRequest = {
     client_id: slasClient.clientConfig.parameters.clientId,
+    channel_id: slasClient.clientConfig.parameters.siteId,
     code: authResponse.code,
     code_verifier: codeVerifier,
     grant_type: "authorization_code_pkce",

--- a/src/static/helpers/slas.ts
+++ b/src/static/helpers/slas.ts
@@ -138,7 +138,13 @@ export async function loginGuestUserPrivate(
     clientSecret: string;
   },
   usid?: string
-): Promise<TokenResponse> {
+): Promise<TokenResponse> {  
+  if (!slasClient.clientConfig.parameters.siteId) {
+    throw new Error(
+      "Required argument channel_id is not provided through clientConfig.parameters.siteId"
+    );
+  }
+
   const authorization = `Basic ${stringToBase64(
     `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
   )}`;
@@ -149,6 +155,7 @@ export async function loginGuestUserPrivate(
     },
     body: {
       grant_type: "client_credentials",
+      channel_id: slasClient.clientConfig.parameters.siteId,
       ...(usid && { usid: usid }),
     },
   };


### PR DESCRIPTION
Starting 7/31/2024, SLAS will start requiring the `channel_id` as a required argument when retrieving an access token with `grant_type: 'client_credentials` for security purposes. This PR updates the `loginGuestUserPrivate` SLAS helper function to require `channel_id`.