### PR TITLE
W-18089100 - allow custom params in helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## CHANGELOG
 
 ## v4.2.0 - future release
-- Allow custom params for 'loginGuestUser' and custom body for 'loginRegisteredUserB2C' function [#186](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186)
+- Allow custom params for 'loginGuestUser' and custom body for 'loginRegisteredUserB2C' function [#415](https://github.com/SalesforceCommerceCloud/commerce-sdk/pull/415)
 
 ## v4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enchancements
 - Support Node 22 [#412](https://github.com/SalesforceCommerceCloud/commerce-sdk/pull/412)
+- Allow custom params for 'loginGuestUser' and custom body for 'loginRegisteredUserB2C' function [#186](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186)
 
 ### API Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## CHANGELOG
 
+## v4.2.0 - future release
+- Allow custom params for 'loginGuestUser' and custom body for 'loginRegisteredUserB2C' function [#186](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186)
+
 ## v4.1.0
 
 ### Enchancements
 - Support Node 22 [#412](https://github.com/SalesforceCommerceCloud/commerce-sdk/pull/412)
-- Allow custom params for 'loginGuestUser' and custom body for 'loginRegisteredUserB2C' function [#186](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186)
 
 ### API Changes
 

--- a/src/static/helpers/slas.ts
+++ b/src/static/helpers/slas.ts
@@ -176,7 +176,7 @@ export async function loginGuestUserPrivate(
  * A single function to execute the ShopperLogin Public Client Guest Login with proof key for code exchange flow as described in the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-public-client.html).
  *
  * @param slasClient a configured instance of the ShopperLogin SDK client.
- * @param parameters - parameters to pass in the API calls.
+ * @param parameters - parameters to pass in the API calls. Custom parameters can be passed in with the prefix `c_` (e.g. c_myParam), and they be passed on the `authorizeCustomer` endpoint.
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @returns TokenResponse

--- a/src/static/helpers/slas.ts
+++ b/src/static/helpers/slas.ts
@@ -17,10 +17,9 @@ import {
   TokenRequest,
   CustomQueryParameters,
   CustomRequestBody,
+  LoginRequest,
 } from "./slasClient";
 import type { RequestRedirect } from "node-fetch";
-import { ShopperLogin } from "../../../renderedTemplates/customer/shopperLogin/shopperLogin";
-import LoginRequest = ShopperLogin.LoginRequest;
 
 /**
  * Converts a string into Base64 encoding

--- a/src/static/helpers/slas.ts
+++ b/src/static/helpers/slas.ts
@@ -90,7 +90,7 @@ export const generateCodeChallenge = async (
  * @param parameters.redirectURI - the location the client will be returned to after successful login with 3rd party IDP. Must be registered in SLAS.
  * @param parameters.hint? - optional string to hint at a particular IDP. Guest sessions are created by setting this to 'guest'
  * @param parameters.usid? - optional saved SLAS user id to link the new session to a previous session
- * @param options - an object containing the options for this function.
+ * @param options? - an object containing the options for this function.
  * @param options.headers - optional headers to pass in the ShopperLogin authorizeCustomer method.
  * @returns login url, user id and authorization code if available
  */
@@ -171,8 +171,8 @@ export async function loginGuestUserPrivate(
 
   const opts = {
     headers: {
+      ...(options?.headers || {}),
       Authorization: authorization,
-      ...options?.headers,
     },
     body: {
       grant_type: "client_credentials",
@@ -277,7 +277,7 @@ export async function loginRegisteredUserB2Cprivate(
   const { usid, redirectURI, ...restOfParams } = parameters;
   const optionsLogin = {
     headers: {
-      ...options?.headers,
+      ...(options?.headers || {}),
       Authorization: authHeaderUserPass,
     },
     ...(Object.keys(restOfParams).length && { parameters: restOfParams }),
@@ -367,8 +367,8 @@ export async function loginRegisteredUserB2C(
 
   const opts = {
     headers: {
-      Authorization: authorization,
       ...(options?.headers || {}),
+      Authorization: authorization,
     },
     parameters: {
       organizationId: slasClient.clientConfig.parameters.organizationId,

--- a/src/static/helpers/slas.ts
+++ b/src/static/helpers/slas.ts
@@ -230,7 +230,7 @@ export async function loginGuestUser(
 
   return slasClient.getAccessToken({
     body: tokenBody,
-    headers: options?.headers,
+    ...(options?.headers && { headers: options.headers }),
     ...(Object.keys(restOfParams).length && { parameters: restOfParams }),
   });
 }
@@ -310,7 +310,7 @@ export async function loginRegisteredUserB2Cprivate(
 
   const optionsToken = {
     headers: {
-      ...(options?.headers || {}),
+      ...options?.headers,
       Authorization: authHeaderIdSecret,
     },
     body: {
@@ -318,8 +318,8 @@ export async function loginRegisteredUserB2Cprivate(
       code_verifier: codeVerifier,
       code: authResponse.code,
       client_id: slasClient.clientConfig.parameters.clientId,
-      redirect_uri: parameters.redirectURI,
-      ...(parameters.usid && { usid: parameters.usid }),
+      redirect_uri: redirectURI,
+      ...(usid && { usid }),
     },
     ...(Object.keys(restOfParams).length && { parameters: restOfParams }),
   };

--- a/src/static/helpers/slas.ts
+++ b/src/static/helpers/slas.ts
@@ -434,7 +434,7 @@ export function refreshAccessToken(
   return slasClient.getAccessToken({
     body,
     ...(options?.headers && { headers: options.headers }),
-    ...(restOfParams && { parameters: restOfParams }),
+    ...(Object.keys(restOfParams).length && { parameters: restOfParams }),
   });
 }
 
@@ -456,6 +456,7 @@ export function refreshAccessTokenPrivate(
   parameters: { refreshToken: string } & CustomQueryParameters,
   options?: { headers?: { [key: string]: string } }
 ): Promise<TokenResponse> {
+  const { refreshToken, ...restOfParams } = parameters;
   const authorization = `Basic ${stringToBase64(
     `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
   )}`;
@@ -464,10 +465,10 @@ export function refreshAccessTokenPrivate(
       Authorization: authorization,
       ...options?.headers,
     },
-    ...(Object.keys(parameters) && { parameters }),
+    ...(Object.keys(restOfParams).length && { parameters: restOfParams }),
     body: {
       grant_type: "refresh_token",
-      refresh_token: parameters.refreshToken,
+      refresh_token: refreshToken,
     },
   };
   return slasClient.getAccessToken(opts);
@@ -492,10 +493,10 @@ export function logout(
   } & CustomQueryParameters,
   options?: { headers?: { [key: string]: string } }
 ): Promise<TokenResponse> {
-  const { refreshToken, ...restOfParams } = parameters;
+  const { refreshToken, accessToken, ...restOfParams } = parameters;
   return slasClient.logoutCustomer({
     headers: {
-      Authorization: `Bearer ${parameters.accessToken}`,
+      Authorization: `Bearer ${accessToken}`,
       ...options?.headers,
     },
     parameters: {

--- a/src/static/helpers/slas.ts
+++ b/src/static/helpers/slas.ts
@@ -17,7 +17,6 @@ import {
   TokenRequest,
   CustomQueryParameters,
   CustomRequestBody,
-  LoginRequest,
 } from "./slasClient";
 import type { RequestRedirect } from "node-fetch";
 

--- a/src/static/helpers/slasClient.ts
+++ b/src/static/helpers/slasClient.ts
@@ -9,7 +9,7 @@ import type { OperationOptions } from "retry";
 import { Response, ClientConfig } from "@commerce-apps/core";
 import type { RequestInit } from "node-fetch";
 
-type LoginRequest = {
+export type LoginRequest = {
   client_id?: string;
   response_type?: string;
   redirect_uri: string;

--- a/src/static/helpers/slasClient.ts
+++ b/src/static/helpers/slasClient.ts
@@ -129,5 +129,5 @@ export type CustomRequestBody = {
     | boolean
     | string[]
     | number[]
-    | { [key: string]: any };
+    | { [key: string]: unknown };
 };

--- a/src/static/helpers/slasClient.ts
+++ b/src/static/helpers/slasClient.ts
@@ -123,5 +123,11 @@ export type CustomQueryParameters = {
  * types for the value.
  */
 export type CustomRequestBody = {
-  [key in `c_${string}`]: string | number | boolean | string[] | number[];
+  [key in `c_${string}`]:
+    | string
+    | number
+    | boolean
+    | string[]
+    | number[]
+    | { [key: string]: any };
 };

--- a/src/static/helpers/slasClient.ts
+++ b/src/static/helpers/slasClient.ts
@@ -109,3 +109,19 @@ export interface ISlasClient {
 
   clientConfig: ClientConfig;
 }
+
+/**
+ * Custom query parameter type with any string prefixed with `c_` as the key and the allowed
+ * types for query parameters for the value.
+ */
+export type CustomQueryParameters = {
+  [key in `c_${string}`]: string | number | boolean | string[] | number[];
+};
+
+/**
+ * Custom body request type with any string prefixed with `c_` as the key and the allowed
+ * types for the value.
+ */
+export type CustomRequestBody = {
+  [key in `c_${string}`]: string | number | boolean | string[] | number[];
+};


### PR DESCRIPTION
This PR allows custom parameters to be passed into `/authorize` endpoint via the `loginGuestUser` and `authorizeIDP` helpers  and `/login` via `loginRegisteredUserB2C` and `loginRegisteredUserB2Cprivate` helper. 

- Customer headers are not allowed and will be ignored via SLAS

Some Note on the authentication endpoints
- The /authorize endpoint does not call SCAPI / OCAPI customers/auth where the hooks take place.
- /login will have authentication hooks. See [here](https://developer.salesforce.com/docs/commerce/commerce-api/guide/hook-method-details.html)