### PR TITLE
Feat: Refactor Node SDK (@W-18136408@)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+## v5.0.0
+- Refactor SLAS helpers
+
+- TODO: update SLAS helper TSdoc comments in isomorphic SDK
 
 ## v4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## CHANGELOG
 
 ## v5.0.0
-- Refactor SLAS helpers
-
-- TODO: update SLAS helper TSdoc comments in isomorphic SDK
+- Enum types have been added for certain operations and types
+- Certain operations have had types updated for query parameters
+- SLAS helpers have been refactored to accept a single `options` object argument, where the properties are the old arguments
+- Path parameter special characters are encoded by default
 
 ## v4.2.0
 

--- a/src/static/helpers/slas.test.ts
+++ b/src/static/helpers/slas.test.ts
@@ -156,11 +156,11 @@ describe("Authorize user", () => {
       .query(true)
       .reply(303, { response_body: "response_body" }, { location: mockURL });
 
-    const authResponse = await slasHelper.authorize(
-      mockSlasClient,
+    const authResponse = await slasHelper.authorize({
+      slasClient: mockSlasClient,
       codeVerifier,
-      params
-    );
+      parameters: params,
+    });
     expect(authResponse).to.be.deep.equal(expectedAuthResponse);
   });
 
@@ -174,11 +174,11 @@ describe("Authorize user", () => {
       .query(true)
       .reply(303, { response_body: "response_body" }, { location: "" });
 
-    const authResponse = await slasHelper.authorize(
-      mockSlasClient,
+    const authResponse = await slasHelper.authorize({
+      slasClient: mockSlasClient,
       codeVerifier,
-      params
-    );
+      parameters: params,
+    });
 
     const authURL = new URL(authResponse.url);
     const expectedURL = new URL(expectedAuthResponseNoLocation.url);
@@ -204,7 +204,11 @@ describe("Authorize user", () => {
       .reply(400);
 
     await slasHelper
-      .authorize(mockSlasClient, codeVerifier, params)
+      .authorize({
+        slasClient: mockSlasClient,
+        codeVerifier,
+        parameters: params,
+      })
       .catch((error) => expect(error.message).to.be.equal("400 Bad Request"));
   });
 });
@@ -241,8 +245,11 @@ describe("Guest user flow", () => {
       .query(true)
       .reply(200, expectedTokenResponse);
 
-    const accessToken = await slasHelper.loginGuestUserPrivate(mockSlasClient, {
-      clientSecret: credentials.clientSecret,
+    const accessToken = await slasHelper.loginGuestUserPrivate({
+      slasClient: mockSlasClient,
+      credentials: {
+        clientSecret: credentials.clientSecret,
+      },
     });
 
     expect(spy.getCall(0).args[0]).to.be.deep.equals(expectedOptionsPrivate);
@@ -263,8 +270,11 @@ describe("Guest user flow", () => {
     };
 
     try {
-      await slasHelper.loginGuestUserPrivate(mockSlasClientNoSiteID, {
-        clientSecret: credentials.clientSecret,
+      await slasHelper.loginGuestUserPrivate({
+        slasClient: mockSlasClientNoSiteID,
+        credentials: {
+          clientSecret: credentials.clientSecret,
+        },
       });
       expect.fail("Expected error not thrown, this line should not be reached");
     } catch (error) {
@@ -290,8 +300,11 @@ describe("Guest user flow", () => {
       .query(true)
       .reply(200, expectedTokenResponse);
 
-    const accessToken = await slasHelper.loginGuestUser(mockSlasClient, {
-      redirectURI: parameters.redirectURI,
+    const accessToken = await slasHelper.loginGuestUser({
+      slasClient: mockSlasClient,
+      parameters: {
+        redirectURI: parameters.redirectURI,
+      },
     });
 
     const options = spy.getCall(0).args[0];
@@ -318,9 +331,12 @@ describe("Guest user flow", () => {
       .post(`/shopper/auth/v1/organizations/${organizationId}/oauth2/token`)
       .query(true)
       .reply(200, expectedTokenResponse);
-    const accessToken = await slasHelper.loginGuestUser(mockSlasClient, {
-      c_cloth: "jeans",
-      redirectURI: parameters.redirectURI,
+    const accessToken = await slasHelper.loginGuestUser({
+      slasClient: mockSlasClient,
+      parameters: {
+        c_cloth: "jeans",
+        redirectURI: parameters.redirectURI,
+      },
     });
 
     const getTokenOpts = getTokenSpy.getCall(0).args[0];
@@ -364,11 +380,11 @@ describe("Registered B2C user flow", () => {
       .query(true)
       .reply(200, expectedTokenResponse);
 
-    const accessToken = await slasHelper.loginRegisteredUserB2Cprivate(
-      mockSlasClient,
+    const accessToken = await slasHelper.loginRegisteredUserB2Cprivate({
+      slasClient: mockSlasClient,
       credentials,
-      params
-    );
+      parameters: params,
+    });
     expect(accessToken).to.be.deep.equals(expectedTokenResponse);
   });
 
@@ -386,11 +402,11 @@ describe("Registered B2C user flow", () => {
       .query(true)
       .reply(200, expectedTokenResponse);
 
-    const accessToken = await slasHelper.loginRegisteredUserB2C(
-      mockSlasClient,
+    const accessToken = await slasHelper.loginRegisteredUserB2C({
+      slasClient: mockSlasClient,
       credentials,
-      params
-    );
+      parameters: params,
+    });
 
     expect(accessToken).to.be.deep.equals(expectedTokenResponse);
   });
@@ -409,12 +425,12 @@ describe("Registered B2C user flow", () => {
       .post(`/shopper/auth/v1/organizations/${organizationId}/oauth2/token`)
       .reply(200, expectedTokenResponse);
 
-    const accessToken = await slasHelper.loginRegisteredUserB2C(
-      mockSlasClient,
+    const accessToken = await slasHelper.loginRegisteredUserB2C({
+      slasClient: mockSlasClient,
       credentials,
-      params,
-      { body: { c_body: "custom-body" } }
-    );
+      parameters: params,
+      body: { c_body: "custom-body" },
+    });
     const authenticateOpts = authenticateSpy.getCall(0).args[0];
     sinon.assert.match(authenticateOpts, {
       headers: {
@@ -449,12 +465,12 @@ describe("Registered B2C user flow", () => {
       .post(`/shopper/auth/v1/organizations/${organizationId}/oauth2/token`)
       .reply(200, expectedTokenResponse);
 
-    const accessToken = await slasHelper.loginRegisteredUserB2Cprivate(
-      mockSlasClient,
+    const accessToken = await slasHelper.loginRegisteredUserB2Cprivate({
+      slasClient: mockSlasClient,
       credentials,
-      params,
-      { body: { c_body: "custom-body" } }
-    );
+      parameters: params,
+      body: { c_body: "custom-body" },
+    });
     const authenticateOpts = authenticateSpy.getCall(0).args[0];
     sinon.assert.match(authenticateOpts, {
       headers: {
@@ -483,7 +499,11 @@ describe("Registered B2C user flow", () => {
       .reply(400);
 
     await slasHelper
-      .loginRegisteredUserB2C(mockSlasClient, credentials, params)
+      .loginRegisteredUserB2C({
+        slasClient: mockSlasClient,
+        credentials,
+        parameters: params,
+      })
       .catch((error) => expect(error.message).to.be.equal("400 Bad Request"));
   });
 
@@ -497,7 +517,11 @@ describe("Registered B2C user flow", () => {
       .reply(400);
 
     await slasHelper
-      .loginRegisteredUserB2Cprivate(mockSlasClient, credentials, params)
+      .loginRegisteredUserB2Cprivate({
+        slasClient: mockSlasClient,
+        credentials,
+        parameters: params,
+      })
       .catch((error) => expect(error.message).to.be.equal("400 Bad Request"));
   });
 });
@@ -520,8 +544,11 @@ describe("Refresh Token", () => {
       .query(true)
       .reply(200, expectedTokenResponse);
 
-    const token = await slasHelper.refreshAccessToken(mockSlasClient, {
-      refreshToken: parameters.refreshToken,
+    const token = await slasHelper.refreshAccessToken({
+      slasClient: mockSlasClient,
+      parameters: {
+        refreshToken: parameters.refreshToken,
+      },
     });
     expect(spy.getCall(0).args[0]).to.be.deep.equals(expectedOpts);
     expect(token).to.be.deep.equals(expectedTokenResponse);
@@ -546,11 +573,11 @@ describe("Refresh Token", () => {
       .query(true)
       .reply(200, expectedTokenResponse);
 
-    const token = await slasHelper.refreshAccessTokenPrivate(
-      mockSlasClient,
+    const token = await slasHelper.refreshAccessTokenPrivate({
+      slasClient: mockSlasClient,
       credentials,
-      { refreshToken: parameters.refreshToken }
-    );
+      parameters: { refreshToken: parameters.refreshToken },
+    });
 
     expect(spy.getCall(0).args[0]).to.be.deep.equals(expectedOptions);
     expect(token).to.be.deep.equals(expectedTokenResponse);
@@ -579,9 +606,12 @@ describe("Logout", () => {
       .query(true)
       .reply(200, expectedTokenResponse);
 
-    const token = await slasHelper.logout(mockSlasClient, {
-      refreshToken: parameters.refreshToken,
-      accessToken: parameters.accessToken,
+    const token = await slasHelper.logout({
+      slasClient: mockSlasClient,
+      parameters: {
+        refreshToken: parameters.refreshToken,
+        accessToken: parameters.accessToken,
+      },
     });
     expect(spy.getCall(0).args[0]).to.be.deep.equals(expectedOptions);
     expect(token).to.be.deep.equals(expectedTokenResponse);

--- a/templatesOas/apis.enum.mustache
+++ b/templatesOas/apis.enum.mustache
@@ -12,15 +12,13 @@ export enum {{operationIdCamelCase}}{{enumName}} {
 }
 {{/stringEnums}}
 {{^stringEnums}}
-
-export const {{operationIdCamelCase}}{{enumName}} = {
+export type {{operationIdCamelCase}}{{enumName}} =
 {{#allowableValues}}
     {{#enumVars}}
-    {{{name}}}: {{{value}}}{{^-last}},{{/-last}}
+    {{{value}}}{{^-last}} |{{/-last}}{{#-last}};{{/-last}}
     {{/enumVars}}
 {{/allowableValues}}
-} as const;
-export type {{operationIdCamelCase}}{{enumName}} = typeof {{operationIdCamelCase}}{{enumName}}[keyof typeof {{operationIdCamelCase}}{{enumName}}];
+
 {{/stringEnums}}
 {{/isEnum}}
 {{/allParams}}


### PR DESCRIPTION
This PR refactors the SDK in breaking ways:
- SLAS helpers accept a single options object argument 
- export only enum types and not a const variable
- Path parameters are URI encoded by default in a separate PR: https://github.com/SalesforceCommerceCloud/commerce-sdk-core/pull/119
