### PR TITLE
Docs: Document Node node-fetch keep-alive regression (@W-23158954@)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Download and install Node.js and npm [here](https://nodejs.org/en/download/).
 ​
 > **Note:** Requirements: Node `^20.x` or `^22.x`. To use a different version of Node.js for other projects, you can manage multiple versions of Node.js with [nvm](https://github.com/nvm-sh/nvm). ​
 
+## Node.js version compatibility
+
+A regression in Node.js 24.17.0 and 22.23.0 caused libraries built on `node-fetch@2` to throw false `ERR_STREAM_PREMATURE_CLOSE` ("Premature close") errors when reusing keep-alive connections. The security fix in those releases added a listener to the socket `'data'` event, which `node-fetch@2` misreads as a truncated response ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989)).
+
+> **Note:** commerce-sdk is **not** affected by this regression. Its HTTP layer is built on `make-fetch-happen`, which does not use the socket-listener heuristic that triggers the false error. The companion [Isomorphic SDK](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic) does depend on `node-fetch@2` directly on its Node.js path, so it is affected; the upgrade guidance below applies to it as to any `node-fetch@2` consumer.
+
+If your application or another dependency uses `node-fetch@2`, upgrade to a Node.js release that contains the [upstream fix](https://github.com/nodejs/node/pull/64004): on the 24.x line use 24.18.0 or later (avoid 24.17.0); on the 22.x line use 22.23.1 or later (avoid 22.23.0). The fixed releases retain the security patch that the regression rode in on, so upgrade forward rather than downgrading.
+
+Newer "Current"-line releases (Node 26.x) that shipped the same security patch are affected as well. As of June 24, 2026 no fixed 26.x release had shipped; check the [Node 26.x changelog](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V26.md) for a release that contains the [upstream fix](https://github.com/nodejs/node/pull/64004). For production, prefer an LTS line (24.x or 22.x) on the fixed versions above.
+
 ## Installation
 
 Use npm to install the Commerce SDK.


### PR DESCRIPTION
## Summary
- Node.js 24.17.0 / 22.23.0 shipped a regression ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989)) where the CVE-2026-48931 security fix attaches a `'data'` listener to keep-alive sockets, which `node-fetch@2` misreads as a truncated response and throws false `ERR_STREAM_PREMATURE_CLOSE`. Customers running a `node-fetch`-based library hit this and reasonably ask whether commerce-sdk is exposed.
- commerce-sdk's HTTP layer is `make-fetch-happen`, which has no such heuristic, so the SDK is **not** affected. This adds a short README section that says so, explains why, and points readers at the fixed Node releases. It also cross-references the [Isomorphic SDK](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic), which depends on `node-fetch@2` directly and **is** affected, so a reader of this SDK's "not affected" note does not over-generalize it to the sibling. README-only, nothing in the SDK changed.

## Acceptance criteria
- [x] README gains a "Node.js version compatibility" section.
- [x] States commerce-sdk is not affected and why (`make-fetch-happen`, no socket-listener heuristic).
- [x] Safe-version guidance: 24.x to 24.18.0+ (avoid 24.17.0); 22.x to 22.23.1+ (avoid 22.23.0).
- [x] Links the upstream bug (#63989) and fix ([#64004](https://github.com/nodejs/node/pull/64004)).
- [x] Cross-references the Isomorphic SDK as the genuinely-affected sibling (direct `node-fetch@2` runtime dependency).
- [x] No code change, no CHANGELOG entry.

## Test plan
- [x] Every load-bearing fact verified against authoritative sources (the Node.js GitHub issue/PR and official nodejs.org release notes): the two regressed versions (24.17.0 / 22.23.0), the two fixed versions (24.18.0 / 22.23.1), the #63989 / #64004 identity, and the `node-fetch@2` `listenerCount('data')` mechanism, all confirmed.
- [x] Dependency claims verified locally in both repos. commerce-sdk: `node-fetch` is neither a direct nor a dev dependency (runtime deps are `@commerce-apps/core`, `nanoid`, `retry`, `tslib`); it appears in `package-lock.json` only transitively, and `make-fetch-happen` is the runtime HTTP path. Isomorphic SDK: `node-fetch@2` is a direct runtime dependency (`require('node-fetch')` on its Node.js path), so it is genuinely affected.
- [x] Edge of the version matrix checked: Node 20.x is correctly omitted (EOL 2026-04-30, never received the June security patch, so never regressed); 26.x (Current) regressed via v26.3.1 with no patched release as of June 24, 2026.
- [x] All four reference links return HTTP 200 (issue #63989, PR #64004, the Node 26.x changelog, the Isomorphic SDK repo).

## Verification
Docs-only, no behavioral surface to smoke-test. Correctness here is factual accuracy of the prose, which was the focus of the test plan above. The 26.x line carries an explicit "as of June 24, 2026" date plus a link to the Node 26.x changelog, so a reader can see how stale the note is and check for a fixed release themselves rather than trusting an undated claim.

## Out of scope
- No code change; no CHANGELOG entry (the SDK did not change).
- No change to the Prerequisites support matrix (`^20.x` / `^22.x`); the section documents an ecosystem regression a reader might hit, not a change to what the SDK supports.
- Documenting the Isomorphic SDK's own remediation (it has a separate ticket and PR); this PR only cross-references it so commerce-sdk readers are not misled.
- Broadcasting beyond the README (Slack / KB) is decided separately.

## Ticket
W-23158954